### PR TITLE
Updated package name and versioning mechanism

### DIFF
--- a/deepracer-build-pkg.sh
+++ b/deepracer-build-pkg.sh
@@ -6,12 +6,16 @@ VERSION_COMMITS=$(git rev-list --count $VERSION_TAG..HEAD)
 VERSION_HASH=$(git rev-parse --short HEAD)
 
 # Check for uncommitted changes
+
 if [ -n "$(git status --porcelain)" ]; then
     VERSION_HASH_SUFFIX="+$VERSION_HASH-dirty"
 else
-    VERSION_HASH_SUFFIX="+$VERSION_HASH"
+    if [ "$VERSION_COMMITS" -gt 0 ]; then
+        VERSION_HASH_SUFFIX="+$VERSION_HASH"
+    else
+        VERSION_HASH_SUFFIX=""
+    fi
 fi
-
 
 # Remove leading 'v' from version tag if present
 if [[ $VERSION_TAG == v* ]]; then

--- a/deepracer-build-pkg.sh
+++ b/deepracer-build-pkg.sh
@@ -1,9 +1,30 @@
 #!/usr/bin/env bash
 export DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+VERSION_TAG=$(git describe --tags --abbrev=0)
+VERSION_COMMITS=$(git rev-list --count $VERSION_TAG..HEAD)
+VERSION_HASH=$(git rev-parse --short HEAD)
+
+# Check for uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then
+    VERSION_HASH_SUFFIX="+$VERSION_HASH-dirty"
+else
+    VERSION_HASH_SUFFIX="+$VERSION_HASH"
+fi
+
+
+# Remove leading 'v' from version tag if present
+if [[ $VERSION_TAG == v* ]]; then
+    VERSION_TAG=${VERSION_TAG:1}
+fi
+
+VERSION=$VERSION_TAG-$VERSION_COMMITS$VERSION_HASH_SUFFIX
+
 rm -rf $DIR/dist/*
 mkdir -p $DIR/dist/opt/aws/deepracer/lib/device_console $DIR/dist/opt/aws/deepracer/lib/device_console/templates $DIR/dist/DEBIAN
 
 cp $DIR/package/control dist/DEBIAN/
+sed -i "s/Version: 0.0.0.0/Version: $VERSION/" $DIR/dist/DEBIAN/control
 cp $DIR/package/postinst dist/DEBIAN/
 cp $DIR/package/prerm dist/DEBIAN/
 
@@ -11,7 +32,7 @@ cp -r $DIR/new/dist/* $DIR/dist/opt/aws/deepracer/lib/device_console
 mv $DIR/dist/opt/aws/deepracer/lib/device_console/*.html $DIR/dist/opt/aws/deepracer/lib/device_console/templates
 mv $DIR/dist/opt/aws/deepracer/lib/device_console/*.json $DIR/dist/opt/aws/deepracer/lib/device_console/static
 
-dpkg-deb --root-owner-group --build $DIR/dist $DIR/dist/aws-deepracer-device-console.deb
-dpkg-name -o $DIR/dist/aws-deepracer-device-console.deb
-FILE=$(compgen -G $DIR/dist/aws-deepracer-device-console*.deb)
+dpkg-deb --root-owner-group --build $DIR/dist $DIR/dist/aws-deepracer-community-device-console.deb
+dpkg-name -o $DIR/dist/aws-deepracer-community-device-console.deb
+FILE=$(compgen -G $DIR/dist/aws-deepracer-community-device-console*.deb)
 mv $FILE $(echo $FILE | sed -e 's/\+/\-/')

--- a/deepracer-build-pkg.sh
+++ b/deepracer-build-pkg.sh
@@ -22,7 +22,7 @@ if [[ $VERSION_TAG == v* ]]; then
     VERSION_TAG=${VERSION_TAG:1}
 fi
 
-VERSION=$VERSION_TAG-$VERSION_COMMITS$VERSION_HASH_SUFFIX
+VERSION=$VERSION_TAG.$VERSION_COMMITS$VERSION_HASH_SUFFIX
 
 rm -rf $DIR/dist/*
 mkdir -p $DIR/dist/opt/aws/deepracer/lib/device_console $DIR/dist/opt/aws/deepracer/lib/device_console/templates $DIR/dist/DEBIAN

--- a/deepracer-build-pkg.sh
+++ b/deepracer-build-pkg.sh
@@ -38,5 +38,9 @@ mv $DIR/dist/opt/aws/deepracer/lib/device_console/*.json $DIR/dist/opt/aws/deepr
 
 dpkg-deb --root-owner-group --build $DIR/dist $DIR/dist/aws-deepracer-community-device-console.deb
 dpkg-name -o $DIR/dist/aws-deepracer-community-device-console.deb
+
+# deb-s3 does not handle filenames with +, so we need to rename the file
 FILE=$(compgen -G $DIR/dist/aws-deepracer-community-device-console*.deb)
-mv $FILE $(echo $FILE | sed -e 's/\+/\-/')
+if [[ $FILE == *"+"* ]]; then
+    mv $FILE $(echo $FILE | sed -e 's/\+/\-/')
+fi

--- a/package/control
+++ b/package/control
@@ -1,7 +1,7 @@
-Package: aws-deepracer-device-console-new
+Package: aws-deepracer-community-device-console
 Replaces: aws-deepracer-device-console
 Provides: aws-deepracer-device-console
-Version: 2.5.0.0+community
+Version: 0.0.0.0
 Section: base
 Priority: optional
 Maintainer: AWS DeepRacer Community


### PR DESCRIPTION
Package is now called aws-deepracer-community-device-console (not aws-deepracer-device-console-new), as it is not a patched and repackaged package, but a 'brand new one'.

The new mechanism is using the git tag as the version number, and adds some suffix to show the number of commits after the last tag and some hash/dirty to make things unique.

Question is how we want to do the major numbering -- the original device console is 2.0; to make things in a similar fashion to what I did with the core package we could start at 2.1. Current logic says that the tag should be e.g. `v2.1.2`, and it will add the last part to make it `2.1.2.0` for the case where there is no commits since the tag and `2.1.2.1+hash` for later versions.