### PR TITLE
Calibration formatting and fixes

### DIFF
--- a/website/src/pages/calibration.tsx
+++ b/website/src/pages/calibration.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useState } from 'react';
-import { TextContent } from "@cloudscape-design/components";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Button,
+  Container,
+  Header,
+  KeyValuePairs,
+  SpaceBetween,
+} from "@cloudscape-design/components";
 import BaseAppLayout from "../components/base-app-layout";
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
-import SpaceBetween from "@cloudscape-design/components/space-between";
-import Button from "@cloudscape-design/components/button";
-import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
-import { useNavigate } from 'react-router-dom';
-import { ApiHelper } from '../common/helpers/api-helper';
+import { ApiHelper } from "../common/helpers/api-helper";
 
 interface CalibrationResponse {
   success: boolean;
@@ -18,29 +19,32 @@ interface CalibrationResponse {
 }
 
 const handleStop = async () => {
-  await ApiHelper.post<{ success: boolean }>('start_stop', { start_stop: 'stop' });
+  await ApiHelper.post<{ success: boolean }>("start_stop", { start_stop: "stop" });
 };
 
 const setCalibration = async () => {
-  await ApiHelper.get<{ success: boolean }>('set_calibration_mode');
+  await ApiHelper.get<{ success: boolean }>("set_calibration_mode");
 };
 
 const getCalibrationAngle = async () => {
-  return await ApiHelper.get<CalibrationResponse>('get_calibration/angle');
+  return await ApiHelper.get<CalibrationResponse>("get_calibration/angle");
 };
 
 const getCalibrationThrottle = async () => {
-  return await ApiHelper.get<CalibrationResponse>('get_calibration/throttle');
+  return await ApiHelper.get<CalibrationResponse>("get_calibration/throttle");
 };
 
 const SteeringContainer = () => {
-  const [calibrationData, setCalibrationData] = useState({ mid: 'Value', max: 'Value', min: 'Value' });
+  const [calibrationData, setCalibrationData] = useState({
+    mid: "Value",
+    max: "Value",
+    min: "Value",
+  });
   const navigate = useNavigate();
 
   useEffect(() => {
     const fetchCalibrationData = async () => {
       await setCalibration();
-      await handleStop();
       const data = await getCalibrationAngle();
       if (data?.success) {
         setCalibrationData({ mid: data.mid, max: data.max, min: data.min });
@@ -53,42 +57,43 @@ const SteeringContainer = () => {
     <Container
       header={
         <Header
-          actions={
-            <SpaceBetween
-              direction="horizontal"
-              size="xs"
-            >
-              <Button onClick={() => navigate('/recalibrate-steering')}>Calibrate</Button>
-            </SpaceBetween>
-          }
+          actions={<Button onClick={() => navigate("/recalibrate-steering")}>Calibrate</Button>}
         >
           Steering
         </Header>
       }
     >
-        <KeyValuePairs
-          columns={3}
-          items={[
-            { label: "Center", value: calibrationData.mid },
-            { label: "Maximum left steering angle", value: calibrationData.max },
-            { label: "Maximum right steering angle", value: calibrationData.min }
-          ]}
-        />
+      <KeyValuePairs
+        columns={3}
+        items={[
+          { label: "Center", value: calibrationData.mid },
+          { label: "Maximum left steering angle", value: calibrationData.max },
+          { label: "Maximum right steering angle", value: calibrationData.min },
+        ]}
+      />
     </Container>
   );
-}
+};
 
 const SpeedContainer = () => {
-  const [calibrationData, setCalibrationData] = useState({ mid: 'Value', max: 'Value', min: 'Value', polarity: 'Value' });
+  const [calibrationData, setCalibrationData] = useState({
+    mid: "Value",
+    max: "Value",
+    min: "Value",
+    polarity: "Value",
+  });
   const navigate = useNavigate();
-  
+
   useEffect(() => {
     const fetchCalibrationData = async () => {
-      await setCalibration();
-      await handleStop();
       const data = await getCalibrationThrottle();
       if (data?.success) {
-        setCalibrationData({ mid: data.mid, max: data.max, min: data.min, polarity: data.polarity });
+        setCalibrationData({
+          mid: data.mid,
+          max: data.max,
+          min: data.min,
+          polarity: data.polarity,
+        });
       }
     };
     fetchCalibrationData();
@@ -97,35 +102,31 @@ const SpeedContainer = () => {
   return (
     <Container
       header={
-        <Header
-          actions={
-            <SpaceBetween
-              direction="horizontal"
-              size="xs"
-            >
-              <Button onClick={() => navigate('/recalibrate-speed')}>Calibrate</Button>
-            </SpaceBetween>
-          }
-        >
+        <Header actions={<Button onClick={() => navigate("/recalibrate-speed")}>Calibrate</Button>}>
           Speed
         </Header>
       }
     >
-        <KeyValuePairs
-          columns={3}
-          items={[
-            { label: "Stopped", value: calibrationData.mid },
-            { label: "Maximum forward speed", value: calibrationData.polarity == '-1' ? calibrationData.min : calibrationData.max },
-            { label: "Maximum backward speed", value: calibrationData.polarity == '-1' ? calibrationData.max : calibrationData.min }
-          ]}
-        />
+      <KeyValuePairs
+        columns={3}
+        items={[
+          { label: "Stopped", value: calibrationData.mid },
+          {
+            label: "Maximum forward speed",
+            value: calibrationData.polarity === "-1" ? calibrationData.min : calibrationData.max,
+          },
+          {
+            label: "Maximum backward speed",
+            value: calibrationData.polarity === "-1" ? calibrationData.max : calibrationData.min,
+          },
+        ]}
+      />
     </Container>
   );
-}
+};
 
 export default function CalibrationPage() {
   useEffect(() => {
-    setCalibration();
     handleStop();
 
     // Clean up calibration mode when unmounting
@@ -134,17 +135,29 @@ export default function CalibrationPage() {
     };
   }, []);
 
+  const description = (
+    <>
+      Calibrate your vehicle to improve its accuracy, reliability and driving behaviors using the{" "}
+      <a
+        href="https://docs.aws.amazon.com/deepracer/latest/developerguide/deepracer-calibrate-vehicle.html?icmpid=docs_deepracer_console"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Calibration Guide
+      </a>
+    </>
+  );
+
   return (
     <BaseAppLayout
       content={
-        <TextContent>
-          <SpaceBetween size="l">
-            <h1>Calibration</h1>
-            <p>Calibrate your vehicle to improve its accuracy, reliability and driving behaviors using the <a href="https://docs.aws.amazon.com/deepracer/latest/developerguide/deepracer-calibrate-vehicle.html?icmpid=docs_deepracer_console" target="_blank" rel="noopener noreferrer">Calibration Guide</a></p>
-            <SteeringContainer />
-            <SpeedContainer />
-          </SpaceBetween>
-        </TextContent>
+        <SpaceBetween size="l">
+          <Header variant="h1" description={description}>
+            Calibration
+          </Header>
+          <SteeringContainer />
+          <SpeedContainer />
+        </SpaceBetween>
       }
     />
   );

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -638,7 +638,6 @@ const HomePage = () => {
                             variant="normal"
                             onClick={() => handleThrottleFive("down")}
                             data-testid="decrease-speed"
-                            disabled={!isModelLoaded}
                           >
                             <svg
                               width="96"
@@ -665,7 +664,6 @@ const HomePage = () => {
                             variant="primary"
                             onClick={() => handleThrottleFive("up")}
                             data-testid="increase-speed"
-                            disabled={!isModelLoaded}
                           >
                             <svg
                               width="96"

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -97,25 +97,25 @@ const HomePage = () => {
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
       switch (event.key.toLowerCase()) {
-        case '+':
-          handleThrottle('up');
+        case "+":
+          handleAutoThrottle(1);
           break;
-        case '-':
-          handleThrottle('down');
+        case "-":
+          handleAutoThrottle(-1);
           break;
-        case 'l':
-          handleThrottleFive('up');
+        case "l":
+          handleAutoThrottle(5);
           break;
-        case 'm':
-          handleThrottleFive('down');
+        case "m":
+          handleAutoThrottle(-5);
           break;
       }
     };
 
-    window.addEventListener('keypress', handleKeyPress);
+    window.addEventListener("keypress", handleKeyPress);
 
     return () => {
-      window.removeEventListener('keypress', handleKeyPress);
+      window.removeEventListener("keypress", handleKeyPress);
     };
   }, []);
 
@@ -132,6 +132,10 @@ const HomePage = () => {
         drive_mode: mode,
       });
       console.log(`Drive mode set to ${mode}:`, response);
+
+      if (response?.success && mode === "auto") {
+        handleAutoThrottle(0);
+      }
     } catch (error) {
       console.error(`Error setting drive mode to ${mode}:`, error);
     }
@@ -206,9 +210,9 @@ const HomePage = () => {
     }
   };
 
-  const handleThrottle = (direction: "up" | "down") => {
+  const handleAutoThrottle = (change: number) => {
     setThrottle((prevThrottle) => {
-      const newThrottle = direction === "up" ? prevThrottle + 1 : prevThrottle - 1;
+      const newThrottle = Math.round(prevThrottle + change);
       ApiHelper.post<DriveResponse>("max_nav_throttle", {
         throttle: newThrottle,
       });
@@ -216,13 +220,9 @@ const HomePage = () => {
     });
   };
 
-  const handleThrottleFive = (direction: "up" | "down") => {
+  const handleManualThrottle = (change: number) => {
     setThrottle((prevThrottle) => {
-      const newThrottle = direction === "up" ? prevThrottle + 5 : prevThrottle - 5;
-      ApiHelper.post<DriveResponse>("max_nav_throttle", {
-        throttle: newThrottle,
-      });
-      return newThrottle;
+      return Math.round(prevThrottle + change);
     });
   };
 
@@ -243,13 +243,13 @@ const HomePage = () => {
 
     lastJoystickMoveTime.current = now;
     const steering = event.x;
-    const throttle = event.y;
-    console.log(`Joystick moved to x: ${steering}, y: ${throttle}`);
+    const joy_throttle = event.y;
+    console.log(`Joystick moved to x: ${steering}, y: ${joy_throttle}`);
     try {
       const modelResponse = axios.put(`/api/manual_drive`, {
         angle: steering,
-        throttle: throttle,
-        max_speed: 0.5,
+        throttle: joy_throttle * -1,
+        max_speed: throttle / 100.0,
       });
       console.log("Model API response:", modelResponse);
     } catch (error) {
@@ -470,7 +470,7 @@ const HomePage = () => {
                           <SpaceBetween size="l" direction="horizontal">
                             <Button
                               variant="normal"
-                              onClick={() => handleThrottle("down")}
+                              onClick={() => handleAutoThrottle(-1)}
                               data-testid="decrease-speed"
                               disabled={!isModelLoaded}
                             >
@@ -486,7 +486,7 @@ const HomePage = () => {
                             </Button>
                             <Button
                               variant="primary"
-                              onClick={() => handleThrottle("up")}
+                              onClick={() => handleAutoThrottle(1)}
                               data-testid="increase-speed"
                               disabled={!isModelLoaded}
                             >
@@ -510,7 +510,7 @@ const HomePage = () => {
                           <SpaceBetween size="l" direction="horizontal">
                             <Button
                               variant="normal"
-                              onClick={() => handleThrottleFive("down")}
+                              onClick={() => handleAutoThrottle(-5)}
                               data-testid="decrease-speed"
                               disabled={!isModelLoaded}
                             >
@@ -537,7 +537,7 @@ const HomePage = () => {
                             </Button>
                             <Button
                               variant="primary"
-                              onClick={() => handleThrottleFive("up")}
+                              onClick={() => handleAutoThrottle(5)}
                               data-testid="increase-speed"
                               disabled={!isModelLoaded}
                             >
@@ -598,7 +598,7 @@ const HomePage = () => {
                         <SpaceBetween size="l" direction="horizontal">
                           <Button
                             variant="normal"
-                            onClick={() => handleThrottle("down")}
+                            onClick={() => handleManualThrottle(-1)}
                             data-testid="decrease-speed"
                           >
                             <svg
@@ -613,7 +613,7 @@ const HomePage = () => {
                           </Button>
                           <Button
                             variant="primary"
-                            onClick={() => handleThrottle("up")}
+                            onClick={() => handleManualThrottle(1)}
                             data-testid="increase-speed"
                           >
                             <svg
@@ -636,7 +636,7 @@ const HomePage = () => {
                         <SpaceBetween size="l" direction="horizontal">
                           <Button
                             variant="normal"
-                            onClick={() => handleThrottleFive("down")}
+                            onClick={() => handleManualThrottle(-5)}
                             data-testid="decrease-speed"
                           >
                             <svg
@@ -662,7 +662,7 @@ const HomePage = () => {
                           </Button>
                           <Button
                             variant="primary"
-                            onClick={() => handleThrottleFive("up")}
+                            onClick={() => handleManualThrottle(5)}
                             data-testid="increase-speed"
                           >
                             <svg

--- a/website/src/pages/recalibrate-speed.tsx
+++ b/website/src/pages/recalibrate-speed.tsx
@@ -1,12 +1,19 @@
-import { useEffect, useState, useRef } from 'react';
-import { TextContent, Container, Grid, ColumnLayout, Button, SpaceBetween } from "@cloudscape-design/components";
+import { useEffect, useState, useRef } from "react";
+import {
+  Container,
+  Grid,
+  Button,
+  SpaceBetween,
+  Header,
+  Box,
+  Alert,
+  Toggle,
+  Slider,
+} from "@cloudscape-design/components";
 import BaseAppLayout from "../components/base-app-layout";
-import { ApiHelper } from '../common/helpers/api-helper';
+import { ApiHelper } from "../common/helpers/api-helper";
 import AnchorNavigation from "@cloudscape-design/components/anchor-navigation";
-import Slider from "@cloudscape-design/components/slider";
-import { useNavigate } from 'react-router-dom';
-import Alert from "@cloudscape-design/components/alert";
-import Toggle from "@cloudscape-design/components/toggle";
+import { useNavigate } from "react-router-dom";
 
 // Add interfaces for API responses
 interface CalibrationResponse {
@@ -22,34 +29,39 @@ interface AdjustWheelsResponse {
 }
 
 const handleStop = async () => {
-  await ApiHelper.post<CalibrationResponse>('start_stop', { start_stop: 'stop' });
+  await ApiHelper.post<CalibrationResponse>("start_stop", { start_stop: "stop" });
 };
 
 const setCalibration = async () => {
-  await ApiHelper.get<CalibrationResponse>('set_calibration_mode');
+  await ApiHelper.get<CalibrationResponse>("set_calibration_mode");
 };
 
 const getCalibrationThrottle = async () => {
-  return await ApiHelper.get<CalibrationResponse>('get_calibration/throttle');
+  return await ApiHelper.get<CalibrationResponse>("get_calibration/throttle");
 };
 
-const setCalibrationThrottle = async (stopped: number, forward: number, backward: number, polar: number) => {
-  return await ApiHelper.post<CalibrationResponse>('set_calibration/throttle', { 
-    mid: stopped, 
-    min: polar == 1 ? backward : -forward, 
-    max: polar == 1 ? forward : -backward,  
-    polarity: polar 
+const setCalibrationThrottle = async (
+  stopped: number,
+  forward: number,
+  backward: number,
+  polar: number
+) => {
+  return await ApiHelper.post<CalibrationResponse>("set_calibration/throttle", {
+    mid: stopped,
+    min: polar == 1 ? backward : -forward,
+    max: polar == 1 ? forward : -backward,
+    polarity: polar,
   });
 };
 
 const adjustCalibratingWheelsThrottle = async (throttleValue: number) => {
-  return await ApiHelper.post<AdjustWheelsResponse>('adjust_calibrating_wheels/throttle', { 
-    pwm: throttleValue 
+  return await ApiHelper.post<AdjustWheelsResponse>("adjust_calibrating_wheels/throttle", {
+    pwm: throttleValue,
   });
 };
 
 export default function RecalibrateSpeedPage() {
-  const [activeAnchor, setActiveAnchor] = useState('#raise');
+  const [activeAnchor, setActiveAnchor] = useState("#raise");
   const [stoppedValue, setStoppedValue] = useState(0);
   const [forwardValue, setForwardValue] = useState(0);
   const [backwardValue, setBackwardValue] = useState(0);
@@ -60,7 +72,7 @@ export default function RecalibrateSpeedPage() {
 
   const lastUpdateTime = useRef<number>(0);
 
-  const [forwardDirectionSpeed, setForwardDirectionSpeed] = useState(20);
+  const [forwardDirectionSpeed, setForwardDirectionSpeed] = useState(10);
 
   const handleStoppedSliderChange = ({ detail }: { detail: { value: number } }) => {
     const now = Date.now();
@@ -99,7 +111,7 @@ export default function RecalibrateSpeedPage() {
   };
 
   const handleStoppedSliderLeft = () => {
-    setStoppedValue(prev => {
+    setStoppedValue((prev) => {
       const newValue = Math.max(prev - 1, -30);
       adjustCalibratingWheelsThrottle(newValue);
       return newValue;
@@ -107,7 +119,7 @@ export default function RecalibrateSpeedPage() {
   };
 
   const handleStoppedSliderRight = () => {
-    setStoppedValue(prev => {
+    setStoppedValue((prev) => {
       const newValue = Math.min(prev + 1, 30);
       adjustCalibratingWheelsThrottle(newValue);
       return newValue;
@@ -115,7 +127,7 @@ export default function RecalibrateSpeedPage() {
   };
 
   const handleForwardSliderLeft = () => {
-    setForwardValue(prev => {
+    setForwardValue((prev) => {
       const newValue = Math.max(prev - 1, getAdjustedRange(0));
       adjustCalibratingWheelsThrottle(newValue);
       return newValue;
@@ -123,7 +135,7 @@ export default function RecalibrateSpeedPage() {
   };
 
   const handleForwardSliderRight = () => {
-    setForwardValue(prev => {
+    setForwardValue((prev) => {
       const newValue = Math.min(prev + 1, getAdjustedRange(50));
       adjustCalibratingWheelsThrottle(newValue);
       return newValue;
@@ -131,7 +143,7 @@ export default function RecalibrateSpeedPage() {
   };
 
   const handleBackwardSliderLeft = () => {
-    setBackwardValue(prev => {
+    setBackwardValue((prev) => {
       const newValue = Math.max(prev - 1, getAdjustedRange(-50));
       adjustCalibratingWheelsThrottle(newValue);
       return newValue;
@@ -139,7 +151,7 @@ export default function RecalibrateSpeedPage() {
   };
 
   const handleBackwardSliderRight = () => {
-    setBackwardValue(prev => {
+    setBackwardValue((prev) => {
       const newValue = Math.min(prev + 1, getAdjustedRange(0));
       adjustCalibratingWheelsThrottle(newValue);
       return newValue;
@@ -147,7 +159,7 @@ export default function RecalibrateSpeedPage() {
   };
 
   const handleDirectionSliderLeft = () => {
-    setForwardDirectionSpeed(prev => {
+    setForwardDirectionSpeed((prev) => {
       const newValue = Math.max(prev - 1, 0);
       adjustCalibratingWheelsThrottle(newValue);
       return newValue;
@@ -155,7 +167,7 @@ export default function RecalibrateSpeedPage() {
   };
 
   const handleDirectionSliderRight = () => {
-    setForwardDirectionSpeed(prev => {
+    setForwardDirectionSpeed((prev) => {
       const newValue = Math.min(prev + 1, 50);
       adjustCalibratingWheelsThrottle(newValue);
       return newValue;
@@ -167,37 +179,36 @@ export default function RecalibrateSpeedPage() {
       const calibrationData = await getCalibrationThrottle();
       if (calibrationData) {
         setStoppedValue(parseFloat(calibrationData.mid));
-        setForwardValue(Math.abs(parseFloat(calibrationData.min))); // Show absolute value initially
-        setBackwardValue(-Math.abs(parseFloat(calibrationData.max))); // Show negative value initially
+        setForwardValue(Math.abs(parseFloat(calibrationData.max))); // Show absolute value initially
+        setBackwardValue(-Math.abs(parseFloat(calibrationData.min))); // Show negative value initially
         setPolarity(calibrationData.polarity ? parseInt(calibrationData.polarity, 10) : 0);
         setOriginalStopped(parseFloat(calibrationData.mid));
-        setChecked(parseInt(calibrationData.polarity || '0', 10) === -1);
+        setChecked(parseInt(calibrationData.polarity || "0", 10) === -1);
       }
     };
-
-    setCalibration();
     handleStop();
     fetchCalibrationValues();
-    window.location.hash = '#raise';
-    setActiveAnchor('#raise');
+    setCalibration();
+    window.location.hash = "#raise";
+    setActiveAnchor("#raise");
   }, []);
 
   useEffect(() => {
     const handleHashChange = () => {
       setActiveAnchor(window.location.hash);
-      if (window.location.hash === '#stopped') {
+      if (window.location.hash === "#stopped") {
         adjustCalibratingWheelsThrottle(stoppedValue);
-      } else if (window.location.hash === '#direction') {
+      } else if (window.location.hash === "#direction") {
         adjustCalibratingWheelsThrottle(forwardDirectionSpeed);
-      } else if (window.location.hash === '#forward') {
+      } else if (window.location.hash === "#forward") {
         adjustCalibratingWheelsThrottle(forwardValue);
-      } else if (window.location.hash === '#backward') {
+      } else if (window.location.hash === "#backward") {
         adjustCalibratingWheelsThrottle(backwardValue);
       }
     };
-    window.addEventListener('hashchange', handleHashChange);
+    window.addEventListener("hashchange", handleHashChange);
     return () => {
-      window.removeEventListener('hashchange', handleHashChange);
+      window.removeEventListener("hashchange", handleHashChange);
     };
   }, [stoppedValue, forwardDirectionSpeed, forwardValue, backwardValue]);
 
@@ -205,50 +216,49 @@ export default function RecalibrateSpeedPage() {
     {
       text: "Raise your vehicle",
       href: "#raise",
-      level: 1
+      level: 1,
     },
     {
       text: "Calibrate stopped speed",
       href: "#stopped",
-      level: 1
+      level: 1,
     },
     {
       text: "Set forward direction",
       href: "#direction",
-      level: 1
+      level: 1,
     },
-    { 
+    {
       text: "Calibrate maximum forward speed",
       href: "#forward",
-      level: 1
+      level: 1,
     },
-    { 
+    {
       text: "Calibrate maximum backward speed",
       href: "#backward",
-      level: 1
-    }
+      level: 1,
+    },
   ];
 
   const handleNavigation = (direction: string) => {
-    const currentIndex = anchors.findIndex(anchor => anchor.href === activeAnchor);
-    if (direction === 'next' && currentIndex < anchors.length - 1) {
+    const currentIndex = anchors.findIndex((anchor) => anchor.href === activeAnchor);
+    if (direction === "next" && currentIndex < anchors.length - 1) {
       window.location.hash = anchors[currentIndex + 1].href;
-    } else if (direction === 'previous' && currentIndex > 0) {
+    } else if (direction === "previous" && currentIndex > 0) {
       window.location.hash = anchors[currentIndex - 1].href;
     }
   };
 
-  const handleCancel = () => {
-    handleStop();
-    adjustCalibratingWheelsThrottle(originalStopped);
-    navigate('/calibration');
+  const handleCancel = async () => {
+    await adjustCalibratingWheelsThrottle(originalStopped);
+    await handleStop();
+    navigate("/calibration");
   };
 
   const handleDone = async () => {
-    await setCalibration();
     await setCalibrationThrottle(stoppedValue, forwardValue, backwardValue, polarity);
-    adjustCalibratingWheelsThrottle(stoppedValue);
-    navigate('/calibration');
+    await adjustCalibratingWheelsThrottle(stoppedValue);
+    navigate("/calibration");
   };
 
   const [checked, setChecked] = useState(false);
@@ -273,69 +283,80 @@ export default function RecalibrateSpeedPage() {
         <Grid gridDefinition={[{ colspan: 3 }, { colspan: 9 }]}>
           <div>
             <AnchorNavigation
-              anchors={anchors.map(anchor => ({
+              anchors={anchors.map((anchor) => ({
                 ...anchor,
-                className: anchor.href === activeAnchor ? '' : 'greyed-out'
+                className: anchor.href === activeAnchor ? "" : "greyed-out",
               }))}
             />
           </div>
           <Container>
-            {activeAnchor === '#raise' && (
-              <ColumnLayout columns={2} variant="text-grid">
+            {activeAnchor === "#raise" && (
+              <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
                 <div>
-                  <TextContent>
-                    <h1>Vehicle Speed Recalibration</h1>
-                    <h2>Raise vehicle</h2>
-                    <p>Raise your vehicle to keep wheels from touching the ground and to key them moving freely.</p>
+                  <SpaceBetween direction="vertical" size="xs">
+                    <Header variant="h1">Vehicle Speed Recalibration</Header>
+                    <Header variant="h2">Raise vehicle</Header>
+                    <Box variant="p">
+                      Raise your vehicle to keep wheels from touching the ground and to key them
+                      moving freely.
+                    </Box>
                     <Alert
-                    statusIconAriaLabel="Warning"
-                    type="warning"
-                    header="Wheels spin at high speeds"
-                  >
-                    Raise your vehicle on a stable surface when calibrating speed
-                  </Alert>
-                  </TextContent>
+                      statusIconAriaLabel="Warning"
+                      type="warning"
+                      header="Wheels spin at high speeds"
+                    >
+                      Raise your vehicle on a stable surface when calibrating speed
+                    </Alert>
+                    <p />
+                  </SpaceBetween>
                 </div>
                 <div>
                   <img src="static/calibrate_raised_ground.svg" alt="Raise Vehicle" />
                 </div>
-              </ColumnLayout>
+              </Grid>
             )}
-            {activeAnchor === '#stopped' && (
-              <ColumnLayout columns={2} variant="text-grid">
-              <div>
-                <TextContent>
-                  <h1>Vehicle Speed Recalibration</h1>
-                  <h2>Stopped speed</h2>
-                  <p>With the vehicle’s wheels free to spin, increase or decrease the Stopped value below until the wheels stop spinning.</p>
-                  <p>Stopped value = {stoppedValue}</p>
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <Button onClick={handleStoppedSliderLeft}>{'<'}</Button>
-                    <Slider
-                      onChange={handleStoppedSliderChange}
-                      value={stoppedValue}
-                      max={30}
-                      min={-30}
-                      referenceValues={[-20, -10, 0, 10, 20]}
-                    />
-                    <Button onClick={handleStoppedSliderRight}>{'>'}</Button>
-                  </div>
-                </TextContent>
-              </div>
-              <div>
-                <img src="static/calibrate_stopped.svg" alt="Calibrate Stopped Speed" />
-              </div>
-            </ColumnLayout>
-            )}
-            {activeAnchor === '#direction' && (
-              <ColumnLayout columns={2} variant="text-grid">
+            {activeAnchor === "#stopped" && (
+              <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
                 <div>
-                  <TextContent>
-                    <h1>Vehicle Speed Recalibration</h1>
-                    <h2>Set forward direction</h2>
-                    <p>Point the vehicle’s front to the right as shown in the diagram. Push the left or right arrow to make the wheels turn. The vehicle will drive forward if the wheels turns clock-wise.</p>
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                      <Button onClick={handleDirectionSliderLeft}>{'<'}</Button>
+                  <SpaceBetween direction="vertical" size="xs">
+                    <Header variant="h1">Vehicle Speed Recalibration</Header>
+                    <Header variant="h2">Stopped speed</Header>
+                    <Box variant="p">
+                      With the vehicle's wheels free to spin, increase or decrease the Stopped value
+                      below until the wheels stop spinning.
+                    </Box>
+                    <Box variant="p">Stopped value = {stoppedValue}</Box>
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <Button onClick={handleStoppedSliderLeft}>{"<"}</Button>
+                      <Slider
+                        onChange={handleStoppedSliderChange}
+                        value={stoppedValue}
+                        max={30}
+                        min={-30}
+                        referenceValues={[-20, -10, 0, 10, 20]}
+                      />
+                      <Button onClick={handleStoppedSliderRight}>{">"}</Button>
+                    </SpaceBetween>
+                  </SpaceBetween>
+                </div>
+                <div>
+                  <img src="static/calibrate_stopped.svg" alt="Calibrate Stopped Speed" />
+                </div>
+              </Grid>
+            )}
+            {activeAnchor === "#direction" && (
+              <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
+                <div>
+                  <SpaceBetween direction="vertical" size="xs">
+                    <Header variant="h1">Vehicle Speed Recalibration</Header>
+                    <Header variant="h2">Set forward direction</Header>
+                    <Box variant="p">
+                      Point the vehicle's front to the right as shown in the diagram. Push the left
+                      or right arrow to make the wheels turn. The vehicle will drive forward if the
+                      wheels turns clock-wise.
+                    </Box>
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <Button onClick={handleDirectionSliderLeft}>{"<"}</Button>
                       <Slider
                         onChange={handleDirectionSliderChange}
                         value={forwardDirectionSpeed}
@@ -343,89 +364,134 @@ export default function RecalibrateSpeedPage() {
                         min={0}
                         referenceValues={[10, 20, 30, 40]}
                       />
-                      <Button onClick={handleDirectionSliderRight}>{'>'}</Button>
-                    </div>
-                    <Alert
-                      statusIconAriaLabel="Warning"
-                      type="warning"
-                    >
-                      If the wheels turn counter clock-wise, toggle on Reverse direction.
-                      <Toggle
-                        onChange={handleToggleChange}
-                        checked={checked}
-                      >
-                        Reverse direction
-                      </Toggle>
+                      <Button onClick={handleDirectionSliderRight}>{">"}</Button>
+                    </SpaceBetween>
+                    <Alert statusIconAriaLabel="Warning" type="warning">
+                      <SpaceBetween direction="vertical" size="xs">
+                        <Box variant="p">
+                          If the wheels turn counter clock-wise, toggle on Reverse direction.
+                        </Box>
+                        <Toggle onChange={handleToggleChange} checked={checked}>
+                          Reverse direction
+                        </Toggle>
+                      </SpaceBetween>
                     </Alert>
-                  </TextContent>
+                    <p />
+                  </SpaceBetween>
                 </div>
                 <div>
                   <img src="static/calibrate_forward.svg" alt="Set Forward Direction" />
                 </div>
-              </ColumnLayout>
+              </Grid>
             )}
-            {activeAnchor === '#forward' && (
-              <ColumnLayout columns={2} variant="text-grid">
+            {activeAnchor === "#forward" && (
+              <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
                 <div>
-                  <TextContent>
-                    <h1>Vehicle Speed Recalibration</h1>
-                    <h2>Maximum forward speed</h2>
-                    <p>Move the slider to set the maximum forward speed on the vehicle so that the Estimated speed value matches, precisely or approximately, the value specified in training the model that is or will be loaded to the vehicle’s inference engine.</p>
-                    <p>Maximum forward speed value = {forwardValue > getAdjustedRange(50) ? getAdjustedRange(50) : (forwardValue) < getAdjustedRange(0) ? getAdjustedRange(0) : (forwardValue)}</p>
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                      <Button onClick={handleForwardSliderLeft}>{'<'}</Button>
+                  <SpaceBetween direction="vertical" size="xs">
+                    <Header variant="h1">Vehicle Speed Recalibration</Header>
+                    <Header variant="h2">Maximum forward speed</Header>
+                    <Box variant="p">
+                      Move the slider to set the maximum forward speed on the vehicle so that the
+                      Estimated speed value matches, precisely or approximately, the value specified
+                      in training the model that is or will be loaded to the vehicle's inference
+                      engine.
+                    </Box>
+                    <Box variant="p">
+                      Maximum forward speed value ={" "}
+                      {forwardValue > getAdjustedRange(50)
+                        ? getAdjustedRange(50)
+                        : forwardValue < getAdjustedRange(0)
+                        ? getAdjustedRange(0)
+                        : forwardValue}
+                    </Box>
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <Button onClick={handleForwardSliderLeft}>{"<"}</Button>
                       <Slider
                         onChange={handleForwardSliderChange}
-                        value={forwardValue > getAdjustedRange(50) ? getAdjustedRange(50) : (forwardValue) < getAdjustedRange(0) ? getAdjustedRange(0) : (forwardValue)}
+                        value={
+                          forwardValue > getAdjustedRange(50)
+                            ? getAdjustedRange(50)
+                            : forwardValue < getAdjustedRange(0)
+                            ? getAdjustedRange(0)
+                            : forwardValue
+                        }
                         max={getAdjustedRange(50)}
                         min={getAdjustedRange(0)}
-                        referenceValues={getReferenceValues(getAdjustedRange(0), getAdjustedRange(50))}
+                        referenceValues={getReferenceValues(
+                          getAdjustedRange(0),
+                          getAdjustedRange(50)
+                        )}
                       />
-                      <Button onClick={handleForwardSliderRight}>{'>'}</Button>
-                    </div>
-                  </TextContent>
+                      <Button onClick={handleForwardSliderRight}>{">"}</Button>
+                    </SpaceBetween>
+                  </SpaceBetween>
                 </div>
                 <div>
                   <img src="static/calibrate_max_forward.svg" alt="Calibrate Forward Speed" />
                 </div>
-              </ColumnLayout>
+              </Grid>
             )}
-            {activeAnchor === '#backward' && (
-              <ColumnLayout columns={2} variant="text-grid">
+            {activeAnchor === "#backward" && (
+              <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
                 <div>
-                  <TextContent>
-                    <h1>Vehicle Speed Recalibration</h1>
-                    <h2>Maximum backward speed</h2>
-                    <p>Move the slider to set the maximum backward speed on the vehicle so that the Estimated speed value matches, precisely or approximately, the value specified in training the model that is or will be loaded to the vehicle’s inference engine.</p>
-                    <p>Maximum backward speed value = {backwardValue > getAdjustedRange(0) ? getAdjustedRange(0) : (backwardValue) < getAdjustedRange(-50) ? getAdjustedRange(-50) : (backwardValue)}</p>
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                      <Button onClick={handleBackwardSliderLeft}>{'<'}</Button>
+                  <SpaceBetween direction="vertical" size="xs">
+                    <Header variant="h1">Vehicle Speed Recalibration</Header>
+                    <Header variant="h2">Maximum backward speed</Header>
+                    <Box variant="p">
+                      Move the slider to set the maximum backward speed on the vehicle so that the
+                      Estimated speed value matches, precisely or approximately, the value specified
+                      in training the model that is or will be loaded to the vehicle's inference
+                      engine.
+                    </Box>
+                    <Box variant="p">
+                      Maximum backward speed value ={" "}
+                      {backwardValue > getAdjustedRange(0)
+                        ? getAdjustedRange(0)
+                        : backwardValue < getAdjustedRange(-50)
+                        ? getAdjustedRange(-50)
+                        : backwardValue}
+                    </Box>
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <Button onClick={handleBackwardSliderLeft}>{"<"}</Button>
                       <Slider
                         onChange={handleBackwardSliderChange}
-                        value={backwardValue > getAdjustedRange(0) ? getAdjustedRange(0) : (backwardValue) < getAdjustedRange(-50) ? getAdjustedRange(-50) : (backwardValue)}
+                        value={
+                          backwardValue > getAdjustedRange(0)
+                            ? getAdjustedRange(0)
+                            : backwardValue < getAdjustedRange(-50)
+                            ? getAdjustedRange(-50)
+                            : backwardValue
+                        }
                         max={getAdjustedRange(0)}
                         min={getAdjustedRange(-50)}
-                        referenceValues={getReferenceValues(getAdjustedRange(-50), getAdjustedRange(0))}
+                        referenceValues={getReferenceValues(
+                          getAdjustedRange(-50),
+                          getAdjustedRange(0)
+                        )}
                       />
-                      <Button onClick={handleBackwardSliderRight}>{'>'}</Button>
-                    </div>
-                  </TextContent>
+                      <Button onClick={handleBackwardSliderRight}>{">"}</Button>
+                    </SpaceBetween>
+                  </SpaceBetween>
                 </div>
                 <div>
                   <img src="static/calibrate_max_backward.svg" alt="Calibrate Backward Speed" />
                 </div>
-              </ColumnLayout>
+              </Grid>
             )}
             <SpaceBetween direction="horizontal" size="xs">
               <Button onClick={handleCancel}>Cancel</Button>
-              {activeAnchor !== '#raise' && (
-                <Button onClick={() => handleNavigation('previous')}>Previous</Button>
+              {activeAnchor !== "#raise" && (
+                <Button onClick={() => handleNavigation("previous")}>Previous</Button>
               )}
-              {activeAnchor !== '#backward' && (
-                <Button variant="primary" onClick={() => handleNavigation('next')}>Next</Button>
+              {activeAnchor !== "#backward" && (
+                <Button variant="primary" onClick={() => handleNavigation("next")}>
+                  Next
+                </Button>
               )}
-              {activeAnchor === '#backward' && (
-                <Button variant="primary" onClick={handleDone}>Done</Button>
+              {activeAnchor === "#backward" && (
+                <Button variant="primary" onClick={handleDone}>
+                  Done
+                </Button>
               )}
             </SpaceBetween>
           </Container>

--- a/website/src/pages/recalibrate-steering.tsx
+++ b/website/src/pages/recalibrate-steering.tsx
@@ -1,11 +1,19 @@
-import { useEffect, useState, useRef } from 'react';
-import { TextContent, Container, Grid, ColumnLayout, Button, SpaceBetween } from "@cloudscape-design/components";
+import { useEffect, useState, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  AnchorNavigation,
+  Alert,
+  Box,
+  Button,
+  Container,
+  Grid,
+  Header,
+  Slider,
+  SpaceBetween,
+  TextContent,
+} from "@cloudscape-design/components";
 import BaseAppLayout from "../components/base-app-layout";
-import AnchorNavigation from "@cloudscape-design/components/anchor-navigation";
-import Alert from "@cloudscape-design/components/alert";
-import { useNavigate } from 'react-router-dom';
-import Slider from "@cloudscape-design/components/slider";
-import { ApiHelper } from '../common/helpers/api-helper';
+import { ApiHelper } from "../common/helpers/api-helper";
 
 // Add interfaces for API responses
 interface CalibrationResponse {
@@ -21,34 +29,34 @@ interface AdjustWheelsResponse {
 }
 
 const handleStop = async () => {
-  await ApiHelper.post<CalibrationResponse>('start_stop', { start_stop: 'stop' });
+  await ApiHelper.post<CalibrationResponse>("start_stop", { start_stop: "stop" });
 };
 
 const setSteeringAngle = async (angle: number) => {
-  await ApiHelper.post<AdjustWheelsResponse>('adjust_calibrating_wheels/angle', { 
-    pwm: angle 
+  await ApiHelper.post<AdjustWheelsResponse>("adjust_calibrating_wheels/angle", {
+    pwm: angle,
   });
 };
 
 const setCalibration = async () => {
-  await ApiHelper.get<CalibrationResponse>('set_calibration_mode');
+  await ApiHelper.get<CalibrationResponse>("set_calibration_mode");
 };
 
 const getCalibrationAngle = async () => {
-  return await ApiHelper.get<CalibrationResponse>('get_calibration/angle');
+  return await ApiHelper.get<CalibrationResponse>("get_calibration/angle");
 };
 
 const setCalibrationAngle = async (center: number, left: number, right: number, polar: number) => {
-  return await ApiHelper.post<CalibrationResponse>('set_calibration/angle', { 
-    mid: center, 
-    min: left, 
-    max: right, 
-    polarity: polar 
+  return await ApiHelper.post<CalibrationResponse>("set_calibration/angle", {
+    mid: center,
+    min: left,
+    max: right,
+    polarity: polar,
   });
 };
 
 export default function RecalibrateSteeringPage() {
-  const [activeAnchor, setActiveAnchor] = useState('#ground');
+  const [activeAnchor, setActiveAnchor] = useState("#ground");
   const [centerValue, setCenterValue] = useState(0);
   const [leftValue, setLeftValue] = useState(0);
   const [rightValue, setRightValue] = useState(0);
@@ -91,7 +99,7 @@ export default function RecalibrateSteeringPage() {
   };
 
   const handleCenterSliderLeft = () => {
-    setCenterValue(prev => {
+    setCenterValue((prev) => {
       const newValue = Math.max(prev - 1, -30);
       setSteeringAngle(newValue);
       return newValue;
@@ -99,7 +107,7 @@ export default function RecalibrateSteeringPage() {
   };
 
   const handleCenterSliderRight = () => {
-    setCenterValue(prev => {
+    setCenterValue((prev) => {
       const newValue = Math.min(prev + 1, 30);
       setSteeringAngle(newValue);
       return newValue;
@@ -107,7 +115,7 @@ export default function RecalibrateSteeringPage() {
   };
 
   const handleLeftSliderLeft = () => {
-    setLeftValue(prev => {
+    setLeftValue((prev) => {
       const newValue = Math.max(prev - 1, -50);
       const invertedValue = newValue > 0 ? -newValue : Math.abs(newValue);
       setSteeringAngle(invertedValue);
@@ -116,7 +124,7 @@ export default function RecalibrateSteeringPage() {
   };
 
   const handleLeftSliderRight = () => {
-    setLeftValue(prev => {
+    setLeftValue((prev) => {
       const newValue = Math.min(prev + 1, 10);
       const invertedValue = newValue > 0 ? -newValue : Math.abs(newValue);
       setSteeringAngle(invertedValue);
@@ -125,7 +133,7 @@ export default function RecalibrateSteeringPage() {
   };
 
   const handleRightSliderLeft = () => {
-    setRightValue(prev => {
+    setRightValue((prev) => {
       const newValue = Math.max(prev - 1, -10);
       const invertedValue = newValue > 0 ? -newValue : Math.abs(newValue);
       setSteeringAngle(invertedValue);
@@ -134,7 +142,7 @@ export default function RecalibrateSteeringPage() {
   };
 
   const handleRightSliderRight = () => {
-    setRightValue(prev => {
+    setRightValue((prev) => {
       const newValue = Math.min(prev + 1, 50);
       const invertedValue = newValue > 0 ? -newValue : Math.abs(newValue);
       setSteeringAngle(invertedValue);
@@ -156,29 +164,29 @@ export default function RecalibrateSteeringPage() {
       }
     };
 
-    setCalibration();
     handleStop();
     fetchCalibrationValues();
-    window.location.hash = '#ground';
-    setActiveAnchor('#ground');
+    setCalibration();
+    window.location.hash = "#ground";
+    setActiveAnchor("#ground");
   }, []);
 
   useEffect(() => {
     const handleHashChange = () => {
       setActiveAnchor(window.location.hash);
-      if (window.location.hash === '#center') {
+      if (window.location.hash === "#center") {
         setSteeringAngle(centerValue);
-      } else if (window.location.hash === '#left') {
-        setLeftValue(prev => -Math.abs(prev));
+      } else if (window.location.hash === "#left") {
+        setLeftValue((prev) => -Math.abs(prev));
         setSteeringAngle(leftValue);
-      } else if (window.location.hash === '#right') {
-        setRightValue(prev => Math.abs(prev));
+      } else if (window.location.hash === "#right") {
+        setRightValue((prev) => Math.abs(prev));
         setSteeringAngle(rightValue);
       }
     };
-    window.addEventListener('hashchange', handleHashChange);
+    window.addEventListener("hashchange", handleHashChange);
     return () => {
-      window.removeEventListener('hashchange', handleHashChange);
+      window.removeEventListener("hashchange", handleHashChange);
     };
   }, [centerValue, leftValue, rightValue]);
 
@@ -186,61 +194,49 @@ export default function RecalibrateSteeringPage() {
     {
       text: "Set your vehicle on the ground",
       href: "#ground",
-      level: 1
+      level: 1,
     },
     {
       text: "Calibrate center",
       href: "#center",
-      level: 1
+      level: 1,
     },
     {
       text: "Calibrate maximum left steering",
       href: "#left",
-      level: 1
+      level: 1,
     },
-    { 
+    {
       text: "Calibrate maximum right steering",
       href: "#right",
-      level: 1
-    }
+      level: 1,
+    },
   ];
 
   const handleNavigation = (direction: string) => {
-    const currentIndex = anchors.findIndex(anchor => anchor.href === activeAnchor);
-    if (direction === 'next' && currentIndex < anchors.length - 1) {
+    const currentIndex = anchors.findIndex((anchor) => anchor.href === activeAnchor);
+    if (direction === "next" && currentIndex < anchors.length - 1) {
       window.location.hash = anchors[currentIndex + 1].href;
-    } else if (direction === 'previous' && currentIndex > 0) {
-      if (activeAnchor === '#left') {
+    } else if (direction === "previous" && currentIndex > 0) {
+      if (activeAnchor === "#left") {
         setSteeringAngle(originalLeft);
-      } else if (activeAnchor === '#right') {
+      } else if (activeAnchor === "#right") {
         setSteeringAngle(originalRight);
       }
       window.location.hash = anchors[currentIndex - 1].href;
     }
   };
 
-  const handleCancel = () => {
-    if (activeAnchor === '#center') {
-      setSteeringAngle(originalCenter);
-    } else if (activeAnchor === '#left') {
-      setSteeringAngle(originalCenter);
-      setSteeringAngle(originalLeft);
-    } else if (activeAnchor === '#right') {
-      setSteeringAngle(originalCenter);
-      setSteeringAngle(originalLeft);
-      setSteeringAngle(originalRight);
-    }
-    navigate('/calibration');
+  const handleCancel = async () => {
+    await setSteeringAngle(originalCenter);
+    await handleStop();
+    navigate("/calibration");
   };
 
   const handleDone = async () => {
-    await setCalibration();
+    await setSteeringAngle(centerValue);
     await setCalibrationAngle(centerValue, leftValue, rightValue, polarity);
-    setSteeringAngle(centerValue);
-    //add a delay to allow the calibration to be set before navigating
-    setTimeout(() => {
-      navigate('/calibration');
-    }, 1000);
+    navigate("/calibration");
   };
 
   // Fix valueFormatter type error
@@ -254,125 +250,145 @@ export default function RecalibrateSteeringPage() {
         <Grid gridDefinition={[{ colspan: 3 }, { colspan: 9 }]}>
           <div>
             <AnchorNavigation
-              anchors={anchors.map(anchor => ({
+              anchors={anchors.map((anchor) => ({
                 ...anchor,
-                className: anchor.href === activeAnchor ? '' : 'greyed-out'
+                className: anchor.href === activeAnchor ? "" : "greyed-out",
               }))}
             />
           </div>
           <Container>
-            {activeAnchor === '#ground' && (
-              <ColumnLayout columns={2} variant="text-grid">
+            {activeAnchor === "#ground" && (
+              <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
                 <div>
                   <TextContent>
-                    <h1>Vehicle Steering Recalibration</h1>
-                    <h2>Set vehicle on the ground</h2>
-                    <p>Place your vehicle on the ground or other hard surface within eyesight. You must be able to see the wheels during steering calibration.</p>
+                    <Header variant="h1">Vehicle Steering Recalibration</Header>
+                    <Header variant="h2">Set vehicle on the ground</Header>
+                    <Box variant="p">
+                      Place your vehicle on the ground or other hard surface within eyesight. You
+                      must be able to see the wheels during steering calibration.
+                    </Box>
                   </TextContent>
                 </div>
                 <div>
                   <img src="static/calibrate_ground.svg" alt="Calibrate Ground" />
                 </div>
-              </ColumnLayout>
+              </Grid>
             )}
-            {activeAnchor === '#center' && (
-              <ColumnLayout columns={2} variant="text-grid">
-              <div>
-                <TextContent>
-                  <h1>Vehicle Steering Recalibration</h1>
-                  <h2>Center steering</h2>
-                  <p>Increase or decrease the Center value to center your vehicle. It is centered when any of the wheels points forward. Use a ruler or straight edge to ensure it is aligned with the rear wheel.</p>
-                  <p>Center value = {centerValue}</p>
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <Button onClick={handleCenterSliderLeft}>{'<'}</Button>
-                    <Slider
-                      onChange={handleCenterSliderChange}
-                      value={centerValue}
-                      max={30}
-                      min={-30}
-                      referenceValues={[-20, -10, 0, 10, 20]}
-                    />
-                    <Button onClick={handleCenterSliderRight}>{'>'}</Button>
-                  </div>
-                  <Alert
-                    statusIconAriaLabel="Info"
-                  >
-                    The front wheels may not be perfectly aligned to each other -- it is important for one front wheel to be facing forward. DeepRacer uses Ackermann steering.
-                  </Alert>
-                  <p></p>
-                </TextContent>
-              </div>
-              <div>
-                <img src="static/calibrate_center.svg" alt="Calibrate Ground" />
-              </div>
-            </ColumnLayout>
+            {activeAnchor === "#center" && (
+              <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
+                <div>
+                  <SpaceBetween direction="vertical" size="xs">
+                    <Header variant="h1">Vehicle Steering Recalibration</Header>
+                    <Header variant="h2">Center steering</Header>
+                    <Box variant="p">
+                      Increase or decrease the Center value to center your vehicle. It is centered
+                      when any of the wheels points forward. Use a ruler or straight edge to ensure
+                      it is aligned with the rear wheel.
+                    </Box>
+                    <Box variant="p">Center value = {centerValue}</Box>
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <Button onClick={handleCenterSliderLeft}>{"<"}</Button>
+                      <Slider
+                        onChange={handleCenterSliderChange}
+                        value={centerValue}
+                        max={30}
+                        min={-30}
+                        referenceValues={[-20, -10, 0, 10, 20]}
+                      />
+                      <Button onClick={handleCenterSliderRight}>{">"}</Button>
+                    </SpaceBetween>
+                    <Alert statusIconAriaLabel="Info">
+                      The front wheels may not be perfectly aligned to each other -- it is important
+                      for one front wheel to be facing forward. DeepRacer uses Ackermann steering.
+                    </Alert>
+                    <p />
+                  </SpaceBetween>
+                </div>
+                <div>
+                  <img src="static/calibrate_center.svg" alt="Calibrate Center" />
+                </div>
+              </Grid>
             )}
-            {activeAnchor === '#left' && (
-              <ColumnLayout columns={2} variant="text-grid">
-              <div>
-                <TextContent>
-                  <h1>Vehicle Steering Recalibration</h1>
-                  <h2>Maximum left steering</h2>
-                  <p>Increase the Value to turn the front wheels to the left until they stop turning.</p>
-                  <p>Value = {leftValue > 0 ? -leftValue : Math.abs(leftValue)}</p>
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <Button onClick={handleLeftSliderLeft}>{'<'}</Button>
-                    <Slider
-                      onChange={handleLeftSliderChange}
-                      value={leftValue}
-                      valueFormatter={valueFormatter}
-                      max={10}
-                      min={-50}
-                      referenceValues={[-40, -30, -20, -10, 0]}
-                    />
-                    <Button onClick={handleLeftSliderRight}>{'>'}</Button>
-                  </div>
-                  <p>Estimated angle: 26-32 degrees</p>
-                </TextContent>
-              </div>
-              <div>
-                <img src="static/calibrate_left.svg" alt="Calibrate Ground" />
-              </div>
-            </ColumnLayout>
+            {activeAnchor === "#left" && (
+              <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
+                <div>
+                  <SpaceBetween direction="vertical" size="l">
+                    <Header variant="h1">Vehicle Steering Recalibration</Header>
+                    <Header variant="h2">Maximum left steering</Header>
+                    <Box variant="p">
+                      Increase the Value to turn the front wheels to the left until they stop
+                      turning.
+                    </Box>
+                    <Box variant="p">
+                      Value = {leftValue > 0 ? -leftValue : Math.abs(leftValue)}
+                    </Box>
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <Button onClick={handleLeftSliderLeft}>{"<"}</Button>
+                      <Slider
+                        onChange={handleLeftSliderChange}
+                        value={leftValue}
+                        valueFormatter={valueFormatter}
+                        max={10}
+                        min={-50}
+                        referenceValues={[-40, -30, -20, -10, 0]}
+                      />
+                      <Button onClick={handleLeftSliderRight}>{">"}</Button>
+                    </SpaceBetween>
+                    <Box variant="p">Estimated angle: 26-32 degrees</Box>
+                  </SpaceBetween>
+                </div>
+                <div>
+                  <img src="static/calibrate_left.svg" alt="Calibrate Left" />
+                </div>
+              </Grid>
             )}
-            {activeAnchor === '#right' && (
-              <ColumnLayout columns={2} variant="text-grid">
-              <div>
-                <TextContent>
-                  <h1>Vehicle Steering Recalibration</h1>
-                  <h2>Maximum right steering</h2>
-                  <p>Increase the Value to turn the front wheels to the right until they stop turning.</p>
-                  <p>Value = {rightValue > 0 ? -rightValue : Math.abs(rightValue)}</p>
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <Button onClick={handleRightSliderLeft}>{'<'}</Button>
-                    <Slider
-                      onChange={handleRightSliderChange}
-                      value={rightValue}
-                      valueFormatter={valueFormatter}
-                      max={50}
-                      min={-10}
-                      referenceValues={[0, 10, 20, 30, 40]}
-                    />
-                    <Button onClick={handleRightSliderRight}>{'>'}</Button>
-                  </div>
-                  <p>Estimated angle: 26-32 degrees</p>
-                </TextContent>
-              </div>
-              <div>
-                <img src="static/calibrate_right.svg" alt="Calibrate Ground" />
-              </div>
-            </ColumnLayout>
+            {activeAnchor === "#right" && (
+              <Grid gridDefinition={[{ colspan: 8 }, { colspan: 4 }]}>
+                <div>
+                  <TextContent>
+                    <Header variant="h1">Vehicle Steering Recalibration</Header>
+                    <Header variant="h2">Maximum right steering</Header>
+                    <Box variant="p">
+                      Increase the Value to turn the front wheels to the right until they stop
+                      turning.
+                    </Box>
+                    <Box variant="p">
+                      Value = {rightValue > 0 ? -rightValue : Math.abs(rightValue)}
+                    </Box>
+                    <SpaceBetween direction="horizontal" size="xs">
+                      <Button onClick={handleRightSliderLeft}>{"<"}</Button>
+                      <Slider
+                        onChange={handleRightSliderChange}
+                        value={rightValue}
+                        valueFormatter={valueFormatter}
+                        max={50}
+                        min={-10}
+                        referenceValues={[0, 10, 20, 30, 40]}
+                      />
+                      <Button onClick={handleRightSliderRight}>{">"}</Button>
+                    </SpaceBetween>
+                    <Box variant="p">Estimated angle: 26-32 degrees</Box>
+                  </TextContent>
+                </div>
+                <div>
+                  <img src="static/calibrate_right.svg" alt="Calibrate Right" />
+                </div>
+              </Grid>
             )}
             <SpaceBetween direction="horizontal" size="xs">
               <Button onClick={handleCancel}>Cancel</Button>
-              {activeAnchor !== '#ground' && (
-                <Button onClick={() => handleNavigation('previous')}>Previous</Button>
+              {activeAnchor !== "#ground" && (
+                <Button onClick={() => handleNavigation("previous")}>Previous</Button>
               )}
-              {activeAnchor !== '#right' && (
-                <Button variant="primary" onClick={() => handleNavigation('next')}>Next</Button>
+              {activeAnchor !== "#right" && (
+                <Button variant="primary" onClick={() => handleNavigation("next")}>
+                  Next
+                </Button>
               )}
-              {activeAnchor === '#right' && (
-                <Button variant="primary" onClick={handleDone}>Done</Button>
+              {activeAnchor === "#right" && (
+                <Button variant="primary" onClick={handleDone}>
+                  Done
+                </Button>
               )}
             </SpaceBetween>
           </Container>


### PR DESCRIPTION
Improves following:
* If you click cancel then the movement of the wheels are stopped. (#63)
* The +/- buttons in Manual mode does not trigger setting of `max_nav_throttle`. When changing to Auto mode this is then submitted. (#65)
* Passes the throttle value into the `manual_drive` API call
* Updated layout on calibration pages.
* Fixed direction of wheels in manual mode.
* Fixed issue where the Min/Max values got swapped if you did calibration twice.