### PR TITLE
Device Status

### DIFF
--- a/website/src/common/hooks/use-supported-apis.ts
+++ b/website/src/common/hooks/use-supported-apis.ts
@@ -5,6 +5,7 @@ import { useAuth } from "./use-authentication";
 interface SupportedApisState {
   supportedApis: string[];
   isEmergencyStopSupported: boolean;
+  isDeviceStatusSupported: boolean;
   isLoading: boolean;
   hasError: boolean;
 }
@@ -22,6 +23,7 @@ export const useSupportedApis = () => {
 export const useSupportedApisProvider = () => {
   const [supportedApis, setSupportedApis] = useState<string[]>([]);
   const [isEmergencyStopSupported, setIsEmergencyStopSupported] = useState<boolean>(false);
+  const [isDeviceStatusSupported, setIsDeviceStatusSupported] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [hasError, setHasError] = useState<boolean>(false);
   const { isAuthenticated } = useAuth();
@@ -31,6 +33,7 @@ export const useSupportedApisProvider = () => {
     if (!isAuthenticated) {
       setSupportedApis([]);
       setIsEmergencyStopSupported(false);
+      setIsDeviceStatusSupported(false);
       setIsLoading(false);
       setHasError(false);
       return;
@@ -48,16 +51,19 @@ export const useSupportedApisProvider = () => {
         if (isSubscribed && response?.success) {
           setSupportedApis(response.apis_supported);
           setIsEmergencyStopSupported(response.apis_supported.includes("/api/emergency_stop"));
+          setIsDeviceStatusSupported(response.apis_supported.includes("/api/get_device_status"));
           setHasError(false);
         } else if (isSubscribed) {
           setSupportedApis([]);
           setIsEmergencyStopSupported(false);
+          setIsDeviceStatusSupported(false);
           setHasError(true);
         }
       } catch (error) {
         console.error("Error checking supported APIs:", error);
         if (isSubscribed) {
           setSupportedApis([]);
+          setIsEmergencyStopSupported(false);
           setIsEmergencyStopSupported(false);
           setHasError(true);
         }
@@ -81,6 +87,7 @@ export const useSupportedApisProvider = () => {
   const supportedApisContextValue: SupportedApisState = {
     supportedApis,
     isEmergencyStopSupported,
+    isDeviceStatusSupported,
     isLoading,
     hasError,
   };

--- a/website/src/components/device-status-panel.tsx
+++ b/website/src/components/device-status-panel.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from "react";
+import {
+  Box,
+  SplitPanel,
+  KeyValuePairs,
+  StatusIndicator,
+  SpaceBetween,
+} from "@cloudscape-design/components";
+import { ApiHelper } from "../common/helpers/api-helper";
+
+interface DeviceStatusProps {
+  isInferenceRunning: boolean;
+}
+
+interface DeviceMetrics {
+  cpuUsage: number;
+  memoryUsage: number;
+  diskUsage: number;
+  temperature: number;
+  cpuFreq: number;
+  cpuFreqMax: number;
+  cpuFreqPct: number;
+}
+
+interface DeviceStatusResponse {
+  success: boolean;
+  cpu_percent: number;
+  memory_usage: number;
+  free_disk: number;
+  cpu_temp: number;
+  cpu_freq: number;
+  cpu_freq_max: number;
+}
+
+const DeviceStatusPanel = ({ isInferenceRunning }: DeviceStatusProps) => {
+  const [metrics, setMetrics] = useState<DeviceMetrics>({
+    cpuUsage: 0,
+    memoryUsage: 0,
+    diskUsage: 0,
+    temperature: 0,
+    cpuFreq: 0,
+    cpuFreqMax: 0,
+    cpuFreqPct: 0,
+  });
+
+  const [updatesSinceInferenceStarted, setUpdatesSinceInferenceStarted] = useState(0);
+
+  useEffect(() => {
+    if (!isInferenceRunning) {
+      console.debug("Inference is not running, resetting updates since inference started.");
+      setUpdatesSinceInferenceStarted(0);
+    }
+  }, [isInferenceRunning]);
+
+  // Use API Helper to fetch real device status
+  useEffect(() => {
+    const fetchDeviceStatus = async () => {
+      try {
+        const response = await ApiHelper.get<DeviceStatusResponse>("get_device_status");
+
+        if (response?.success) {
+          setMetrics({
+            cpuUsage: parseFloat(response.cpu_percent.toFixed(0)),
+            memoryUsage: parseFloat(response.memory_usage.toFixed(1)),
+            diskUsage: parseFloat((100 - response.free_disk).toFixed(1)),
+            temperature: parseFloat(response.cpu_temp.toFixed(1)),
+            cpuFreq: parseFloat(response.cpu_freq.toFixed(0)),
+            cpuFreqMax: parseFloat(response.cpu_freq_max.toFixed(0)),
+            cpuFreqPct: (response.cpu_freq / response.cpu_freq_max) * 100,
+          });
+
+          if (isInferenceRunning) {
+            setUpdatesSinceInferenceStarted((prev) => prev + 1);
+          }
+        }
+      } catch (error) {
+        console.error("Error fetching device status:", error);
+      }
+    };
+
+    fetchDeviceStatus(); // Initial fetch
+    const intervalId = setInterval(fetchDeviceStatus, 4000);
+
+    return () => clearInterval(intervalId);
+  }, [isInferenceRunning]); // Remove updatesSinceInferenceStarted from dependency array
+
+  const getStatusType = (
+    value: number,
+    thresholds: [number, number]
+  ): "success" | "warning" | "error" => {
+    const [warning, error] = thresholds;
+    if (value < warning) return "success";
+    if (value < error) return "warning";
+    return "error";
+  };
+
+  const getCPUStatusType = (
+    value: number,
+    thresholds: [number, number],
+    isInferenceRunning: boolean
+  ): "info" | "success" | "warning" | "error" => {
+    if (!isInferenceRunning) return "info";
+    const [warning, error] = thresholds;
+    if (value > warning) return "success";
+    if (value > error) return "warning";
+    return "error";
+  };
+
+  return (
+    <SplitPanel
+      header={"Device Status"}
+      i18nStrings={{ preferencesTitle: "Preferences" }}
+      hidePreferencesButton={true}
+      closeBehavior="collapse"
+    >
+      <SpaceBetween size="xs" direction="vertical">
+        <KeyValuePairs
+          columns={4}
+          items={[
+            {
+              label: "CPU",
+              value: (
+                <SpaceBetween size="m" direction="horizontal">
+                  <Box>Usage:</Box>
+                  <StatusIndicator type={getStatusType(metrics.cpuUsage, [60, 80])}>
+                    {metrics.cpuUsage}%
+                  </StatusIndicator>
+                  <Box>Temp:</Box>{" "}
+                  <StatusIndicator type={getStatusType(metrics.temperature, [45, 55])}>
+                    {metrics.temperature}°C
+                  </StatusIndicator>
+                </SpaceBetween>
+              ),
+            },
+            {
+              label: "CPU Frequency",
+              value: (
+                <StatusIndicator
+                  type={getCPUStatusType(
+                    metrics.cpuFreqPct,
+                    [75, 50],
+                    isInferenceRunning && updatesSinceInferenceStarted > 1
+                  )}
+                >
+                  {metrics.cpuFreq} MHz / {metrics.cpuFreqMax} MHz
+                </StatusIndicator>
+              ),
+            },
+            {
+              label: "Memory Usage",
+              value: (
+                <StatusIndicator type={getStatusType(metrics.memoryUsage, [70, 85])}>
+                  {metrics.memoryUsage}%
+                </StatusIndicator>
+              ),
+            },
+            {
+              label: "Disk Usage",
+              value: (
+                <StatusIndicator type={getStatusType(metrics.diskUsage, [70, 90])}>
+                  {metrics.diskUsage}%
+                </StatusIndicator>
+              ),
+            },
+          ]}
+        />
+      </SpaceBetween>
+    </SplitPanel>
+  );
+};
+
+export default DeviceStatusPanel;

--- a/website/src/components/device-status-panel.tsx
+++ b/website/src/components/device-status-panel.tsx
@@ -52,7 +52,7 @@ const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatu
     memory: { warning: 85, error: 95 },
     disk: { warning: 90, error: 95 },
     performance: {
-      latency_p95: { warning: 1.2, error: 1.4 },
+      latency_p95: { warning: 1.25, error: 1.5 },
       fps_mean: { warning: 1.05, error: 1.1 },
     },
   });

--- a/website/src/components/device-status-panel.tsx
+++ b/website/src/components/device-status-panel.tsx
@@ -197,7 +197,6 @@ const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatu
           ),
           warningMessage: "CPU Frequency is low",
           errorMessage: "CPU Frequency is critically low",
-          updateDelay: 2,
           noInferenceStatus: "info" as "info" | "stopped" | "pending",
         },
       },
@@ -219,7 +218,6 @@ const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatu
           ),
           warningMessage: "CPU Usage is high",
           errorMessage: "CPU Usage is extremely high",
-          updateDelay: 2,
         },
         "device-status-latency": {
           metricValue: metrics.latencyMean,
@@ -232,7 +230,6 @@ const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatu
           ),
           warningMessage: "Latency is high",
           errorMessage: "Latency is critically high",
-          updateDelay: 2,
           noInferenceStatus: "stopped" as "info" | "stopped" | "pending",
         },
         "device-status-latency-p95": {
@@ -246,7 +243,6 @@ const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatu
           ),
           warningMessage: "95% Latency is high",
           errorMessage: "95% Latency is critically high",
-          updateDelay: 2,
           noInferenceStatus: "stopped" as "info" | "stopped" | "pending",
         },
         "device-status-fps-mean": {
@@ -260,7 +256,6 @@ const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatu
           ),
           warningMessage: "Frame Rate is low",
           errorMessage: "Frame Rate is critically low",
-          updateDelay: 2,
           noInferenceStatus: "stopped" as "info" | "stopped" | "pending",
         },
       },

--- a/website/src/components/device-status-panel.tsx
+++ b/website/src/components/device-status-panel.tsx
@@ -45,7 +45,7 @@ const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatu
   // Define thresholds for different metrics
   const [thresholds] = useState({
     cpu: {
-      usage: { warning: 90, error: 95 },
+      usage: { warning: 90, error: 99 },
       temperature: { warning: 75, error: 90 },
       frequency: { warning: 75, error: 50 }, // Note: For CPU frequency, higher is better
     },
@@ -321,7 +321,7 @@ const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatu
                 type={checkPerformanceStatus(
                   metrics.latencyP95,
                   metrics.latencyMean,
-                  [thresholds.performance.latency_p95.warning, thresholds.performance.latency_p95.warning],
+                  [thresholds.performance.latency_p95.warning, thresholds.performance.latency_p95.error],
                   isInferenceRunning
                 )}
               >

--- a/website/src/components/device-status-panel.tsx
+++ b/website/src/components/device-status-panel.tsx
@@ -1,15 +1,18 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import {
   Box,
   SplitPanel,
   KeyValuePairs,
   StatusIndicator,
   SpaceBetween,
+  FlashbarProps,
 } from "@cloudscape-design/components";
 import { ApiHelper } from "../common/helpers/api-helper";
 
 interface DeviceStatusProps {
   isInferenceRunning: boolean;
+  notifications?: FlashbarProps.MessageDefinition[];
+  setNotifications: React.Dispatch<React.SetStateAction<FlashbarProps.MessageDefinition[]>>;
 }
 
 interface DeviceMetrics {
@@ -32,7 +35,18 @@ interface DeviceStatusResponse {
   cpu_freq_max: number;
 }
 
-const DeviceStatusPanel = ({ isInferenceRunning }: DeviceStatusProps) => {
+const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatusProps) => {
+  // Define thresholds for different metrics
+  const [thresholds] = useState({
+    cpu: {
+      usage: { warning: 90, error: 95 },
+      temperature: { warning: 75, error: 90 },
+      frequency: { warning: 75, error: 50 }, // Note: For CPU frequency, higher is better
+    },
+    memory: { warning: 85, error: 95 },
+    disk: { warning: 90, error: 95 },
+  });
+
   const [metrics, setMetrics] = useState<DeviceMetrics>({
     cpuUsage: 0,
     memoryUsage: 0,
@@ -45,12 +59,99 @@ const DeviceStatusPanel = ({ isInferenceRunning }: DeviceStatusProps) => {
 
   const [updatesSinceInferenceStarted, setUpdatesSinceInferenceStarted] = useState(0);
 
+  const removeFlashMessage = useCallback(
+    (id: string) => {
+      setNotifications((prev) => prev.filter((message) => message.id !== id));
+    },
+    [setNotifications]
+  );
+
+  const addFlashMessage = useCallback(
+    (id: string, content: string, type: FlashbarProps.Type) => {
+      // Check if a message with this ID already exists and update it if needed
+      setNotifications((prev) => {
+        const existingMessageIndex = prev.findIndex(message => message.id === id);
+        
+        // Create the new/updated message
+        const newMessage: FlashbarProps.MessageDefinition = {
+          id,
+          content,
+          type,
+          dismissible: type !== "in-progress",
+          onDismiss: type !== "in-progress" ? () => removeFlashMessage(id) : undefined,
+        };
+        
+        // If message already exists, update it
+        if (existingMessageIndex >= 0) {
+          const updatedMessages = [...prev];
+          updatedMessages[existingMessageIndex] = newMessage;
+          return updatedMessages;
+        }
+        
+        // Otherwise add a new message
+        return [...prev, newMessage];
+      });
+      return id; // Return the id of the new/updated message
+    },
+    [removeFlashMessage, setNotifications]
+  );
+
   useEffect(() => {
     if (!isInferenceRunning) {
       console.debug("Inference is not running, resetting updates since inference started.");
       setUpdatesSinceInferenceStarted(0);
     }
   }, [isInferenceRunning]);
+
+  // Separate effect for handling warning and error messages based on metrics
+  useEffect(() => {
+    // Check CPU usage
+    const cpuUsageId = "device-status-cpu-usage";
+    if (metrics.cpuUsage >= thresholds.cpu.usage.error) {
+      addFlashMessage(cpuUsageId, "CPU Usage is extremely high", "error");
+    } else if (metrics.cpuUsage >= thresholds.cpu.usage.warning) {
+      addFlashMessage(cpuUsageId, "CPU Usage is getting high", "warning");
+    } else {
+      removeFlashMessage(cpuUsageId);
+    }
+
+    // Check CPU temperature
+    const cpuTempId = "device-status-cpu-temp";
+    if (metrics.temperature >= thresholds.cpu.temperature.error) {
+      addFlashMessage(cpuTempId, "CPU Temperature is extremely high", "error");
+    } else if (metrics.temperature >= thresholds.cpu.temperature.warning) {
+      addFlashMessage(cpuTempId, "CPU Temperature is getting high", "warning");
+    } else {
+      removeFlashMessage(cpuTempId);
+    }
+
+    // Check memory usage
+    const memoryUsageId = "device-status-memory-usage";
+    if (metrics.memoryUsage >= thresholds.memory.error) {
+      addFlashMessage(memoryUsageId, "Memory Usage is extremely high", "error");
+    } else if (metrics.memoryUsage >= thresholds.memory.warning) {
+      addFlashMessage(memoryUsageId, "Memory Usage is getting high", "warning");
+    } else {
+      removeFlashMessage(memoryUsageId);
+    }
+
+    // Check disk usage
+    const diskUsageId = "device-status-disk-usage";
+    if (metrics.diskUsage >= thresholds.disk.error) {
+      addFlashMessage(diskUsageId, "Disk Usage is extremely high", "error");
+    } else if (metrics.diskUsage >= thresholds.disk.warning) {
+      addFlashMessage(diskUsageId, "Disk Usage is getting high", "warning");
+    } else {
+      removeFlashMessage(diskUsageId);
+    }
+  }, [metrics, addFlashMessage, removeFlashMessage, thresholds]);
+
+  // Count updates since inference started
+  useEffect(() => {
+    if (isInferenceRunning) {
+      setUpdatesSinceInferenceStarted((prev) => prev + 1);
+    }
+  }, [metrics, isInferenceRunning]);
 
   // Use API Helper to fetch real device status
   useEffect(() => {
@@ -68,10 +169,6 @@ const DeviceStatusPanel = ({ isInferenceRunning }: DeviceStatusProps) => {
             cpuFreqMax: parseFloat(response.cpu_freq_max.toFixed(0)),
             cpuFreqPct: (response.cpu_freq / response.cpu_freq_max) * 100,
           });
-
-          if (isInferenceRunning) {
-            setUpdatesSinceInferenceStarted((prev) => prev + 1);
-          }
         }
       } catch (error) {
         console.error("Error fetching device status:", error);
@@ -82,13 +179,13 @@ const DeviceStatusPanel = ({ isInferenceRunning }: DeviceStatusProps) => {
     const intervalId = setInterval(fetchDeviceStatus, 4000);
 
     return () => clearInterval(intervalId);
-  }, [isInferenceRunning]); // Remove updatesSinceInferenceStarted from dependency array
+  }, []); // Remove updatesSinceInferenceStarted from dependency array
 
-  const getStatusType = (
+  const checkStatus = (
     value: number,
-    thresholds: [number, number]
+    thresholdPair: [number, number]
   ): "success" | "warning" | "error" => {
-    const [warning, error] = thresholds;
+    const [warning, error] = thresholdPair;
     if (value < warning) return "success";
     if (value < error) return "warning";
     return "error";
@@ -96,23 +193,18 @@ const DeviceStatusPanel = ({ isInferenceRunning }: DeviceStatusProps) => {
 
   const getCPUStatusType = (
     value: number,
-    thresholds: [number, number],
+    thresholdPair: [number, number],
     isInferenceRunning: boolean
   ): "info" | "success" | "warning" | "error" => {
     if (!isInferenceRunning) return "info";
-    const [warning, error] = thresholds;
+    const [warning, error] = thresholdPair;
     if (value > warning) return "success";
     if (value > error) return "warning";
     return "error";
   };
 
   return (
-    <SplitPanel
-      header={"Device Status"}
-      i18nStrings={{ preferencesTitle: "Preferences" }}
-      hidePreferencesButton={true}
-      closeBehavior="collapse"
-    >
+    <SplitPanel header={"Car Health"} hidePreferencesButton={true} closeBehavior="collapse">
       <SpaceBetween size="xs" direction="vertical">
         <KeyValuePairs
           columns={4}
@@ -122,11 +214,21 @@ const DeviceStatusPanel = ({ isInferenceRunning }: DeviceStatusProps) => {
               value: (
                 <SpaceBetween size="m" direction="horizontal">
                   <Box>Usage:</Box>
-                  <StatusIndicator type={getStatusType(metrics.cpuUsage, [60, 80])}>
+                  <StatusIndicator
+                    type={checkStatus(metrics.cpuUsage, [
+                      thresholds.cpu.usage.warning,
+                      thresholds.cpu.usage.error,
+                    ])}
+                  >
                     {metrics.cpuUsage}%
                   </StatusIndicator>
                   <Box>Temp:</Box>{" "}
-                  <StatusIndicator type={getStatusType(metrics.temperature, [45, 55])}>
+                  <StatusIndicator
+                    type={checkStatus(metrics.temperature, [
+                      thresholds.cpu.temperature.warning,
+                      thresholds.cpu.temperature.error,
+                    ])}
+                  >
                     {metrics.temperature}°C
                   </StatusIndicator>
                 </SpaceBetween>
@@ -138,8 +240,8 @@ const DeviceStatusPanel = ({ isInferenceRunning }: DeviceStatusProps) => {
                 <StatusIndicator
                   type={getCPUStatusType(
                     metrics.cpuFreqPct,
-                    [75, 50],
-                    isInferenceRunning && updatesSinceInferenceStarted > 1
+                    [thresholds.cpu.frequency.warning, thresholds.cpu.frequency.error],
+                    isInferenceRunning && updatesSinceInferenceStarted > 2
                   )}
                 >
                   {metrics.cpuFreq} MHz / {metrics.cpuFreqMax} MHz
@@ -149,7 +251,12 @@ const DeviceStatusPanel = ({ isInferenceRunning }: DeviceStatusProps) => {
             {
               label: "Memory Usage",
               value: (
-                <StatusIndicator type={getStatusType(metrics.memoryUsage, [70, 85])}>
+                <StatusIndicator
+                  type={checkStatus(metrics.memoryUsage, [
+                    thresholds.memory.warning,
+                    thresholds.memory.error,
+                  ])}
+                >
                   {metrics.memoryUsage}%
                 </StatusIndicator>
               ),
@@ -157,7 +264,12 @@ const DeviceStatusPanel = ({ isInferenceRunning }: DeviceStatusProps) => {
             {
               label: "Disk Usage",
               value: (
-                <StatusIndicator type={getStatusType(metrics.diskUsage, [70, 90])}>
+                <StatusIndicator
+                  type={checkStatus(metrics.diskUsage, [
+                    thresholds.disk.warning,
+                    thresholds.disk.error,
+                  ])}
+                >
                   {metrics.diskUsage}%
                 </StatusIndicator>
               ),

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   ExpandableSection,
+  FlashbarProps,
   Grid,
   Header,
   KeyValuePairs,
@@ -62,6 +63,9 @@ const HomePage = () => {
   const [isSplitPanelOpen, setIsSplitPanelOpen] = useState(false);
   const [splitPanelSize, setSplitPanelSize] = useState(150);
 
+  const [localFlashMessages, setLocalFlashMessages] = useState<FlashbarProps.MessageDefinition[]>(
+    []
+  );
   // Check for scrollbars after render and on resize
   useLayoutEffect(() => {
     const checkForScrollbars = () => {
@@ -173,9 +177,6 @@ const HomePage = () => {
     // Cleanup on component unmount
     return () => {
       clearInterval(intervalId);
-      if (cameraImgRef.current) {
-        cameraImgRef.current.src = ""; // Clear camera feed source
-      }
     };
   }, []);
 
@@ -301,8 +302,7 @@ const HomePage = () => {
 
   return (
     <BaseAppLayout
-      // Any page-specific notifications can be passed as additionalNotifications
-      // additionalNotifications={[{...}]}  // Only if you have page-specific notifications
+      additionalNotifications={[...localFlashMessages]}
       content={
         <div ref={divLayoutRef}>
           <SpaceBetween size="l">
@@ -706,7 +706,11 @@ const HomePage = () => {
       }
       splitPanel={
         isDeviceStatusSupported ? (
-          <DeviceStatusPanel isInferenceRunning={isInferenceRunning} />
+          <DeviceStatusPanel
+            isInferenceRunning={isInferenceRunning}
+            notifications={localFlashMessages}
+            setNotifications={setLocalFlashMessages}
+          />
         ) : undefined
       }
       splitPanelOpen={isSplitPanelOpen}

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -61,7 +61,7 @@ const HomePage = () => {
   // Split panel
   const { isDeviceStatusSupported } = useSupportedApis();
   const [isSplitPanelOpen, setIsSplitPanelOpen] = useState(false);
-  const [splitPanelSize, setSplitPanelSize] = useState(150);
+  const [splitPanelSize, setSplitPanelSize] = useState(220);
 
   const [localFlashMessages, setLocalFlashMessages] = useState<FlashbarProps.MessageDefinition[]>(
     []

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -16,9 +16,11 @@ import axios from "axios";
 import { useEffect, useRef, useState, useLayoutEffect } from "react";
 import { Joystick } from "react-joystick-component";
 import BaseAppLayout from "../components/base-app-layout";
+import DeviceStatusPanel from "../components/device-status-panel";
 import { ApiHelper } from "../common/helpers/api-helper";
 import { useModels } from "../common/hooks/use-models";
 import { useAuth } from "../common/hooks/use-authentication";
+import { useSupportedApis } from "../common/hooks/use-supported-apis";
 
 // Add interfaces for API responses
 interface SensorStatusResponse {
@@ -54,6 +56,11 @@ const HomePage = () => {
   const { modelOptions, selectedModel, isModelLoaded, setSelectedModel, loadModel, reloadModels } =
     useModels();
   const { isAuthenticated } = useAuth();
+
+  // Split panel
+  const { isDeviceStatusSupported } = useSupportedApis();
+  const [isSplitPanelOpen, setIsSplitPanelOpen] = useState(false);
+  const [splitPanelSize, setSplitPanelSize] = useState(150);
 
   // Check for scrollbars after render and on resize
   useLayoutEffect(() => {
@@ -697,6 +704,15 @@ const HomePage = () => {
           </SpaceBetween>
         </div>
       }
+      splitPanel={
+        isDeviceStatusSupported ? (
+          <DeviceStatusPanel isInferenceRunning={isInferenceRunning} />
+        ) : undefined
+      }
+      splitPanelOpen={isSplitPanelOpen}
+      splitPanelSize={splitPanelSize}
+      onSplitPanelToggle={({ detail }) => setIsSplitPanelOpen(detail.open)}
+      onSplitPanelResize={({ detail }) => setSplitPanelSize(detail.size)}
     />
   );
 };


### PR DESCRIPTION
This pull request introduces support for a new "Device Status" feature, enhancing the application's ability to monitor system metrics and display alerts. Key changes include updates to the `useSupportedApis` hook, the addition of a new `DeviceStatusPanel` component, and integration of the panel into the `HomePage` layout.

### Enhancements to API support:

* Added `isDeviceStatusSupported` to the `SupportedApisState` interface and the `useSupportedApisProvider` hook, enabling the application to check if the "Device Status" API is supported. (`website/src/common/hooks/use-supported-apis.ts`) [[1]](diffhunk://#diff-17ddbd3e5182f01471039402f159e927c79a7ca35664ea326e8e9ca2ac3b1705R8) [[2]](diffhunk://#diff-17ddbd3e5182f01471039402f159e927c79a7ca35664ea326e8e9ca2ac3b1705R26) [[3]](diffhunk://#diff-17ddbd3e5182f01471039402f159e927c79a7ca35664ea326e8e9ca2ac3b1705R36) [[4]](diffhunk://#diff-17ddbd3e5182f01471039402f159e927c79a7ca35664ea326e8e9ca2ac3b1705R54-R67) [[5]](diffhunk://#diff-17ddbd3e5182f01471039402f159e927c79a7ca35664ea326e8e9ca2ac3b1705R90)

### New Device Status feature:

* Implemented `DeviceStatusPanel` component to display system metrics (CPU, memory, disk usage, etc.) with real-time updates and alerts for critical thresholds. (`website/src/components/device-status-panel.tsx`)

### Integration into HomePage:

* Updated `HomePage` to include the `DeviceStatusPanel` in a split panel layout, conditionally rendered based on `isDeviceStatusSupported`. Added local notification handling for alerts from the panel. (`website/src/pages/home.tsx`) [[1]](diffhunk://#diff-5efea2270bf71dff8831370d4cc75e1b41b7b3b381ae40f5fff06f02d3ebded2R5) [[2]](diffhunk://#diff-5efea2270bf71dff8831370d4cc75e1b41b7b3b381ae40f5fff06f02d3ebded2R20-R24) [[3]](diffhunk://#diff-5efea2270bf71dff8831370d4cc75e1b41b7b3b381ae40f5fff06f02d3ebded2R61-R68) [[4]](diffhunk://#diff-5efea2270bf71dff8831370d4cc75e1b41b7b3b381ae40f5fff06f02d3ebded2L297-R305) [[5]](diffhunk://#diff-5efea2270bf71dff8831370d4cc75e1b41b7b3b381ae40f5fff06f02d3ebded2R707-R719)

Example:
![image](https://github.com/user-attachments/assets/753e8b39-90f8-40ff-8b69-f6b3ed20cb50)
