### PR TITLE
Refactored use-battery hook

### DIFF
--- a/website/src/common/hooks/use-battery.ts
+++ b/website/src/common/hooks/use-battery.ts
@@ -35,20 +35,25 @@ export const useBattery = () => {
 };
 
 export const useBatteryProvider = () => {
-  // Battery state
-  const [batteryLevel, setBatteryLevel] = useState<number>(0);
-  const [batteryError, setBatteryError] = useState<boolean>(false);
-  const [batteryWarningDismissed, setBatteryWarningDismissed] = useState(false);
-  const [batteryErrorDismissed, setBatteryErrorDismissed] = useState(false);
-  const [hasInitialReading, setHasInitialReading] = useState(false);
   const [pageLoadTime] = useState<number>(Date.now());
   const { isAuthenticated } = useAuth();
   const { get: apiGet } = useApi();
 
-  // Battery notifications state
-  const [batteryFlashbarItems, setBatteryFlashbarItems] = useState<
-    FlashbarProps.MessageDefinition[]
-  >([]);
+  // Use a single state object that matches BatteryState interface
+  const [batteryState, setBatteryState] = useState<BatteryState>({
+    batteryLevel: 0,
+    batteryError: false,
+    hasInitialReading: false,
+    batteryWarningDismissed: false,
+    batteryErrorDismissed: false,
+    setBatteryWarningDismissed: (dismissed: boolean) => {
+      setBatteryState((prev) => ({ ...prev, batteryWarningDismissed: dismissed }));
+    },
+    setBatteryErrorDismissed: (dismissed: boolean) => {
+      setBatteryState((prev) => ({ ...prev, batteryErrorDismissed: dismissed }));
+    },
+    batteryFlashbarItems: [],
+  });
 
   // Update battery notifications whenever relevant state changes
   useEffect(() => {
@@ -58,42 +63,51 @@ export const useBatteryProvider = () => {
     // Only show notifications if authenticated
     if (isAuthenticated) {
       // Battery error notification
-      if ((batteryError || (!hasInitialReading && hasBeenTenSeconds)) && !batteryErrorDismissed) {
+      if (
+        (batteryState.batteryError || (!batteryState.hasInitialReading && hasBeenTenSeconds)) &&
+        !batteryState.batteryErrorDismissed
+      ) {
         notifications.push({
           type: "error" as FlashbarProps.Type,
           content:
-            !hasInitialReading && hasBeenTenSeconds
+            !batteryState.hasInitialReading && hasBeenTenSeconds
               ? "Unable to get battery reading"
               : "Vehicle battery is not connected",
           dismissible: true,
           dismissLabel: "Dismiss message",
           id: "battery-error",
-          onDismiss: () => setBatteryErrorDismissed(true),
+          onDismiss: () => batteryState.setBatteryErrorDismissed(true),
         });
       }
 
       // Battery warning notification
-      if (batteryLevel <= 40 && !batteryError && !batteryWarningDismissed && hasInitialReading) {
+      if (
+        batteryState.batteryLevel <= 40 &&
+        !batteryState.batteryError &&
+        !batteryState.batteryWarningDismissed &&
+        batteryState.hasInitialReading
+      ) {
         notifications.push({
           type: "warning" as FlashbarProps.Type,
-          content: `Battery Level is at ${batteryLevel}%`,
+          content: `Battery Level is at ${batteryState.batteryLevel}%`,
           dismissible: true,
           dismissLabel: "Dismiss message",
           id: "battery-warning",
-          onDismiss: () => setBatteryWarningDismissed(true),
+          onDismiss: () => batteryState.setBatteryWarningDismissed(true),
         });
       }
     }
 
-    setBatteryFlashbarItems(notifications);
+    setBatteryState((prev) => ({ ...prev, batteryFlashbarItems: notifications }));
   }, [
-    batteryLevel,
-    batteryError,
-    hasInitialReading,
-    batteryWarningDismissed,
-    batteryErrorDismissed,
+    batteryState.batteryLevel,
+    batteryState.batteryError,
+    batteryState.hasInitialReading,
+    batteryState.batteryWarningDismissed,
+    batteryState.batteryErrorDismissed,
     pageLoadTime,
     isAuthenticated,
+    batteryState,
   ]);
 
   // Battery status management
@@ -103,31 +117,44 @@ export const useBatteryProvider = () => {
       return;
     }
 
+    // Don't fetch battery data if on system-unavailable page
+    if (window.location.hash.includes("/system-unavailable")) {
+      return;
+    }
+
     let isSubscribed = true;
 
     const updateBatteryStatus = async () => {
       try {
-        const batteryData = await getBatteryStatus();
+        const batteryData = await apiGet<BatteryResponse>("get_battery_level");
         if (isSubscribed && batteryData) {
           if (batteryData.success) {
-            setHasInitialReading(true);
+            setBatteryState((prev) => ({
+              ...prev,
+              hasInitialReading: true,
+              batteryError: batteryData.battery_level === -1,
+              batteryLevel:
+                batteryData.battery_level === -1 ? 0 : (batteryData.battery_level / 10) * 100,
+              batteryWarningDismissed:
+                batteryData.battery_level === -1 ? false : prev.batteryWarningDismissed,
+              // Only reset error dismissal if the error state is changing from false to true
+              batteryErrorDismissed: batteryData.battery_level === -1 && !prev.batteryError ? false : prev.batteryErrorDismissed,
+            }));
+
             if (batteryData.battery_level === -1) {
               console.debug("Battery level is -1, indicating battery not connected");
-              setBatteryError(true);
-              setBatteryLevel(0);
-              setBatteryWarningDismissed(false);
-              setBatteryErrorDismissed(false);
             } else {
               const calculatedLevel = (batteryData.battery_level / 10) * 100;
               console.debug(
                 `Setting battery level to ${calculatedLevel}% (raw: ${batteryData.battery_level})`
               );
-              setBatteryError(false);
-              setBatteryLevel(calculatedLevel);
-              setBatteryErrorDismissed(false);
               if (batteryData.battery_level <= 4) {
                 console.debug(`Low battery warning: ${batteryData.battery_level}/10`);
-                setBatteryWarningDismissed(false);
+                // Only reset warning dismissal if we're transitioning to low battery from non-low battery
+                setBatteryState((prev) => ({ 
+                  ...prev, 
+                  batteryWarningDismissed: prev.batteryLevel > 40 ? false : prev.batteryWarningDismissed 
+                }));
               }
             }
           } else {
@@ -137,21 +164,16 @@ export const useBatteryProvider = () => {
       } catch (error) {
         console.error("Error updating battery status:", error);
         if (isSubscribed) {
-          setBatteryError(true);
-          setBatteryLevel(0);
-          setBatteryWarningDismissed(false);
-          setBatteryErrorDismissed(false);
+          setBatteryState((prev) => ({
+            ...prev,
+            batteryError: true,
+            batteryLevel: 0,
+            // Only reset warning dismissal if we're transitioning from non-error to error
+            batteryWarningDismissed: !prev.batteryError ? false : prev.batteryWarningDismissed,
+            // Only reset error dismissal if we're transitioning from no error to error
+            batteryErrorDismissed: !prev.batteryError ? false : prev.batteryErrorDismissed,
+          }));
         }
-      }
-    };
-
-    const getBatteryStatus = async () => {
-      try {
-        const response = await apiGet<BatteryResponse>("get_battery_level");
-        return response;
-      } catch (error) {
-        console.error("Error fetching battery status:", error);
-        return null;
       }
     };
 
@@ -168,16 +190,5 @@ export const useBatteryProvider = () => {
     };
   }, [isAuthenticated, apiGet]); // Add isAuthenticated as a dependency
 
-  const batteryContextValue: BatteryState = {
-    batteryLevel,
-    batteryError,
-    hasInitialReading,
-    batteryWarningDismissed,
-    batteryErrorDismissed,
-    setBatteryWarningDismissed,
-    setBatteryErrorDismissed,
-    batteryFlashbarItems,
-  };
-
-  return batteryContextValue;
+  return batteryState;
 };


### PR DESCRIPTION
This pull request refactors the `useBatteryProvider` hook in `website/src/common/hooks/use-battery.ts` to simplify state management by consolidating multiple state variables into a single `batteryState` object. It also introduces improvements to error handling and notification logic. Below are the key changes:

### State Management Refactor:
* Consolidated multiple state variables (e.g., `batteryLevel`, `batteryError`, `batteryWarningDismissed`) into a single `batteryState` object that conforms to the `BatteryState` interface. This reduces redundancy and simplifies state updates.

### Notification Logic Updates:
* Updated the logic for displaying error and warning notifications to use the new `batteryState` object. This ensures consistent access to state properties and simplifies the notification handling code.

### Error Handling Enhancements:
* Improved error handling when fetching battery data by resetting specific state properties only when transitioning into an error state. This prevents unnecessary resets and maintains user-dismissed states where applicable. [[1]](diffhunk://#diff-82900d85c79e7122da4125361bf36d59b5a6841e99af6a848051b09db154658fR120-R157) [[2]](diffhunk://#diff-82900d85c79e7122da4125361bf36d59b5a6841e99af6a848051b09db154658fL140-L154)

### API Integration:
* Replaced the `getBatteryStatus` function with a direct call to `apiGet<BatteryResponse>("get_battery_level")`, streamlining the code and removing an unnecessary wrapper function.

### Return Value Simplification:
* Simplified the return value of the hook by directly returning the `batteryState` object instead of constructing a separate `batteryContextValue`.