### PR TITLE
Fix Calibration Move Issue

### DIFF
--- a/website/src/pages/calibration.tsx
+++ b/website/src/pages/calibration.tsx
@@ -36,9 +36,9 @@ const getCalibrationThrottle = async () => {
 
 const SteeringContainer = () => {
   const [calibrationData, setCalibrationData] = useState({
-    mid: "Value",
-    max: "Value",
-    min: "Value",
+    mid: "-",
+    max: "-",
+    min: "-",
   });
   const navigate = useNavigate();
 
@@ -47,7 +47,11 @@ const SteeringContainer = () => {
       await setCalibration();
       const data = await getCalibrationAngle();
       if (data?.success) {
-        setCalibrationData({ mid: data.mid, max: data.max, min: data.min });
+        setCalibrationData({
+          mid: Math.abs(Number(data.mid)) > 100 ? "-" : data.mid,
+          max: Math.abs(Number(data.max)) > 100 ? "-" : data.max,
+          min: Math.abs(Number(data.min)) > 100 ? "-" : data.min,
+        });
       }
     };
     fetchCalibrationData();
@@ -66,8 +70,8 @@ const SteeringContainer = () => {
       <KeyValuePairs
         columns={3}
         items={[
-          { label: "Center", value: calibrationData.mid },
           { label: "Maximum left steering angle", value: calibrationData.max },
+          { label: "Center", value: calibrationData.mid },
           { label: "Maximum right steering angle", value: calibrationData.min },
         ]}
       />
@@ -77,10 +81,10 @@ const SteeringContainer = () => {
 
 const SpeedContainer = () => {
   const [calibrationData, setCalibrationData] = useState({
-    mid: "Value",
-    max: "Value",
-    min: "Value",
-    polarity: "Value",
+    mid: "-",
+    max: "-",
+    min: "-",
+    polarity: "-",
   });
   const navigate = useNavigate();
 
@@ -89,9 +93,9 @@ const SpeedContainer = () => {
       const data = await getCalibrationThrottle();
       if (data?.success) {
         setCalibrationData({
-          mid: data.mid,
-          max: data.max,
-          min: data.min,
+          mid: Math.abs(Number(data.mid)) > 100 ? "-" : data.mid,
+          max: Math.abs(Number(data.max)) > 100 ? "-" : data.max,
+          min: Math.abs(Number(data.min)) > 100 ? "-" : data.min,
           polarity: data.polarity,
         });
       }
@@ -110,11 +114,11 @@ const SpeedContainer = () => {
       <KeyValuePairs
         columns={3}
         items={[
-          { label: "Stopped", value: calibrationData.mid },
           {
             label: "Maximum forward speed",
             value: calibrationData.polarity === "-1" ? calibrationData.min : calibrationData.max,
           },
+          { label: "Stopped", value: calibrationData.mid },
           {
             label: "Maximum backward speed",
             value: calibrationData.polarity === "-1" ? calibrationData.max : calibrationData.min,
@@ -128,11 +132,6 @@ const SpeedContainer = () => {
 export default function CalibrationPage() {
   useEffect(() => {
     handleStop();
-
-    // Clean up calibration mode when unmounting
-    return () => {
-      handleStop();
-    };
   }, []);
 
   const description = (

--- a/website/src/pages/recalibrate-speed.tsx
+++ b/website/src/pages/recalibrate-speed.tsx
@@ -74,6 +74,7 @@ export default function RecalibrateSpeedPage() {
   const [originalStopped, setOriginalStopped] = useState(0);
 
   const lastUpdateTime = useRef<number>(0);
+  const actionRef = useRef(false);
 
   const [forwardDirectionSpeed, setForwardDirectionSpeed] = useState(10);
 
@@ -193,11 +194,17 @@ export default function RecalibrateSpeedPage() {
     setCalibration();
     window.location.hash = "#raise";
     setActiveAnchor("#raise");
-
-    return () => {
-      handleStop();
-    };
   }, []);
+
+  useEffect(() => {
+    return () => {
+      if (!actionRef.current) {
+        console.log("Abort speed calibration. Resetting throttle to original zero value.");
+        adjustCalibratingWheelsThrottle(originalStopped);
+        handleStop();
+      }
+    };
+  }, [originalStopped]);
 
   useEffect(() => {
     const handleHashChange = () => {
@@ -257,11 +264,24 @@ export default function RecalibrateSpeedPage() {
   };
 
   const handleCancel = async () => {
+    actionRef.current = true;
+    console.log("Cancel speed calibration. Resetting throttle to original zero value.");
     await adjustCalibratingWheelsThrottle(originalStopped);
     navigate("/calibration");
   };
 
   const handleDone = async () => {
+    actionRef.current = true;
+    console.log(
+      "Saved speed calibration. Max forward speed:",
+      forwardValue,
+      "Stopped value:",
+      stoppedValue,
+      "Max backward speed:",
+      backwardValue,
+      "Polarity:",
+      polarity
+    );
     await setCalibrationThrottle(stoppedValue, forwardValue, backwardValue, polarity);
     await adjustCalibratingWheelsThrottle(stoppedValue);
     navigate("/calibration");

--- a/website/src/pages/recalibrate-speed.tsx
+++ b/website/src/pages/recalibrate-speed.tsx
@@ -31,6 +31,9 @@ interface AdjustWheelsResponse {
 const handleStop = async () => {
   await ApiHelper.post<CalibrationResponse>("start_stop", { start_stop: "stop" });
 };
+const handleStart = async () => {
+  await ApiHelper.post<CalibrationResponse>("start_stop", { start_stop: "start" });
+};
 
 const setCalibration = async () => {
   await ApiHelper.get<CalibrationResponse>("set_calibration_mode");
@@ -186,17 +189,21 @@ export default function RecalibrateSpeedPage() {
         setChecked(parseInt(calibrationData.polarity || "0", 10) === -1);
       }
     };
-    handleStop();
     fetchCalibrationValues();
     setCalibration();
     window.location.hash = "#raise";
     setActiveAnchor("#raise");
+
+    return () => {
+      handleStop();
+    };
   }, []);
 
   useEffect(() => {
     const handleHashChange = () => {
       setActiveAnchor(window.location.hash);
       if (window.location.hash === "#stopped") {
+        handleStart();
         adjustCalibratingWheelsThrottle(stoppedValue);
       } else if (window.location.hash === "#direction") {
         adjustCalibratingWheelsThrottle(forwardDirectionSpeed);
@@ -251,7 +258,6 @@ export default function RecalibrateSpeedPage() {
 
   const handleCancel = async () => {
     await adjustCalibratingWheelsThrottle(originalStopped);
-    await handleStop();
     navigate("/calibration");
   };
 

--- a/website/src/pages/recalibrate-steering.tsx
+++ b/website/src/pages/recalibrate-steering.tsx
@@ -71,6 +71,7 @@ export default function RecalibrateSteeringPage() {
   const [originalRight, setOriginalRight] = useState(0);
 
   const lastUpdateTime = useRef<number>(0);
+  const actionRef = useRef(false);
 
   const handleCenterSliderChange = ({ detail }: { detail: { value: number } }) => {
     const now = Date.now();
@@ -171,11 +172,19 @@ export default function RecalibrateSteeringPage() {
     setCalibration();
     window.location.hash = "#ground";
     setActiveAnchor("#ground");
-
-    return () => {
-      handleStop();
-    };
   }, []);
+
+  useEffect(() => {
+    return () => {
+      if (!actionRef.current) {
+        console.log(
+          "Abort steering calibration. Resetting steering angle to original center value."
+        );
+        setSteeringAngle(originalCenter);
+        handleStop();
+      }
+    };
+  }, [originalCenter]);
 
   useEffect(() => {
     const handleHashChange = () => {
@@ -235,14 +244,29 @@ export default function RecalibrateSteeringPage() {
   };
 
   const handleCancel = async () => {
+    actionRef.current = true;
     await setSteeringAngle(originalCenter);
     await handleStop();
+    console.log(
+      "Cancelled steering calibration. Resetting steering angle to original center value."
+    );
     navigate("/calibration");
   };
 
   const handleDone = async () => {
+    actionRef.current = true;
     await setSteeringAngle(centerValue);
     await setCalibrationAngle(centerValue, leftValue, rightValue, polarity);
+    console.log(
+      "Saved steering calibration. Left:",
+      leftValue,
+      "Center:",
+      centerValue,
+      "Right:",
+      rightValue
+    );
+
+    await handleStop();
     navigate("/calibration");
   };
 

--- a/website/src/pages/recalibrate-steering.tsx
+++ b/website/src/pages/recalibrate-steering.tsx
@@ -31,6 +31,10 @@ const handleStop = async () => {
   await ApiHelper.post<CalibrationResponse>("start_stop", { start_stop: "stop" });
 };
 
+const handleStart = async () => {
+  await ApiHelper.post<CalibrationResponse>("start_stop", { start_stop: "start" });
+};
+
 const setSteeringAngle = async (angle: number) => {
   await ApiHelper.post<AdjustWheelsResponse>("adjust_calibrating_wheels/angle", {
     pwm: angle,
@@ -163,17 +167,21 @@ export default function RecalibrateSteeringPage() {
       }
     };
 
-    handleStop();
     fetchCalibrationValues();
     setCalibration();
     window.location.hash = "#ground";
     setActiveAnchor("#ground");
+
+    return () => {
+      handleStop();
+    };
   }, []);
 
   useEffect(() => {
     const handleHashChange = () => {
       setActiveAnchor(window.location.hash);
       if (window.location.hash === "#center") {
+        handleStart();
         setSteeringAngle(centerValue);
       } else if (window.location.hash === "#left") {
         setLeftValue((prev) => -Math.abs(prev));


### PR DESCRIPTION
Fixes #99 

Original bug is that the servos did not move in calibration mode. This is caused by `start_stop` API calls with `stop` value, but none with `start` value.

Following limitations are now included.
- `start_stop` API does not actually start/stop the car, it only enables/disables any commands to be sent to the servos. If the car is at top speed it will continue at top speed after a stop call.
- In calibration `start_stop` should be triggered with a `start` value.
- In calibration best practice is to reset to the old or new center/stop values when cancelling, when saving ("Done") as well as when navigating away.
- The main calibration page actually does not do anything.

Additionally:
- If the value returned for calibration values is invalid (>100 etc.) then display `-`.
- Console logging increased.