### PR TITLE
Implement diffdrive in configuration

### DIFF
--- a/website/src/components/settings/car-config-container.tsx
+++ b/website/src/components/settings/car-config-container.tsx
@@ -62,6 +62,11 @@ const LOGGING_MODE_TILES: TilesProps.TilesDefinition[] = [
   { value: "Always", label: "Always", description: "Logs saved regardless of USB drive presence" },
 ];
 
+const LOGGING_PROVIDER_TILES: TilesProps.TilesDefinition[] = [
+  { value: "sqlite3", label: "SQLite3", description: "Lightweight single-file database, compatible with all ROS distros" },
+  { value: "mcap", label: "MCAP", description: "Modern container format for ROS 2 Humble and later" },
+];
+
 const STEERING_MODE_TILES: TilesProps.TilesDefinition[] = [
   {
     value: "servo",
@@ -191,14 +196,6 @@ export const CarConfigContainer = () => {
       const devices = ["auto", ...(caps?.inference_devices[normEngine] ?? [])];
       const withDefaults: CarConfig = {
         ...cfg,
-        logging: {
-          ...cfg.logging,
-          mode: matchCI(
-            cfg.logging.mode,
-            LOGGING_MODE_TILES.map((t) => t.value),
-            "Never"
-          ),
-        },
         camera: {
           ...cfg.camera,
           mode: matchCI(
@@ -218,6 +215,19 @@ export const CarConfigContainer = () => {
             cfg.steering?.mode,
             STEERING_MODE_TILES.map((t) => t.value),
             "servo"
+          ),
+        },
+        logging: {
+          ...cfg.logging,
+          mode: matchCI(
+            cfg.logging.mode,
+            LOGGING_MODE_TILES.map((t) => t.value),
+            "Never"
+          ),
+          provider: matchCI(
+            cfg.logging.provider,
+            LOGGING_PROVIDER_TILES.map((t) => t.value),
+            "sqlite3"
           ),
         },
       };
@@ -248,14 +258,6 @@ export const CarConfigContainer = () => {
       const devices = ["auto", ...(caps?.inference_devices[normEngine] ?? [])];
       const withDefaults: CarConfig = {
         ...cfg,
-        logging: {
-          ...cfg.logging,
-          mode: matchCI(
-            cfg.logging.mode,
-            LOGGING_MODE_TILES.map((t) => t.value),
-            "Never"
-          ),
-        },
         camera: {
           ...cfg.camera,
           mode: matchCI(
@@ -277,6 +279,19 @@ export const CarConfigContainer = () => {
             "servo"
           ),
         },
+        logging: {
+          ...cfg.logging,
+          mode: matchCI(
+            cfg.logging.mode,
+            LOGGING_MODE_TILES.map((t) => t.value),
+            "Never"
+          ),
+          provider: matchCI(
+            cfg.logging.provider,
+            LOGGING_PROVIDER_TILES.map((t) => t.value),
+            "sqlite3"
+          ),
+        },
       };
       setConfig(withDefaults);
       setDraft(withDefaults);
@@ -294,6 +309,10 @@ export const CarConfigContainer = () => {
     setDraft((prev) => prev && { ...prev, logging: { ...prev.logging, mode: value } });
   };
 
+  const updateLoggingProvider = (value: string) => {
+    setDraft((prev) => prev && { ...prev, logging: { ...prev.logging, provider: value } });
+  };
+
   const updateCamera = (value: string) => {
     setDraft((prev) => prev && { ...prev, camera: { ...prev.camera, mode: value } });
   };
@@ -308,6 +327,14 @@ export const CarConfigContainer = () => {
     draft?.inference.engine ?? "auto",
     draft?.inference.device ?? "auto",
     inferenceTiles
+  );
+
+  const cameraTiles = CAMERA_MODE_TILES.filter(
+    (t) => t.value === "auto" || capabilities?.camera_modes?.includes(t.value)
+  );
+
+  const steeringTiles = STEERING_MODE_TILES.filter((t) =>
+    capabilities?.steering_modes?.includes(t.value)
   );
 
   const updateInference = (tileValue: string) => {
@@ -334,68 +361,95 @@ export const CarConfigContainer = () => {
 
       <Container
         header={
-          <Header variant="h2" description="Controls when driving logs are recorded to a ROS bag.">
-            Logging Mode
+          <Header variant="h2">
+            Logging
           </Header>
         }
       >
-        <Tiles
-          value={draft?.logging.mode ?? null}
-          items={LOGGING_MODE_TILES.map((t) => ({ ...t, disabled: isLoading }))}
-          onChange={({ detail }) => updateLogging(detail.value)}
-        />
+        <SpaceBetween size="l">
+          <div>
+            <Header variant="h3" description="Controls when driving logs are recorded to a ROS bag.">
+              Mode
+            </Header>
+            <Tiles
+              value={draft?.logging.mode ?? null}
+              items={LOGGING_MODE_TILES.map((t) => ({ ...t, disabled: isLoading }))}
+              onChange={({ detail }) => updateLogging(detail.value)}
+            />
+          </div>
+          {(capabilities?.logging_providers?.length ?? 0) > 1 && (
+            <div>
+              <Header variant="h3" description="Storage format used when writing ROS bag files.">
+                Provider
+              </Header>
+              <Tiles
+                value={draft?.logging.provider ?? null}
+                items={LOGGING_PROVIDER_TILES.filter((t) =>
+                  capabilities?.logging_providers?.includes(t.value)
+                ).map((t) => ({ ...t, disabled: isLoading }))}
+                onChange={({ detail }) => updateLoggingProvider(detail.value)}
+              />
+            </div>
+          )}
+        </SpaceBetween>
       </Container>
 
-      <Container
-        header={
-          <Header
-            variant="h2"
-            description="Controls which camera driver is used to capture the video feed."
-          >
-            Camera Mode
-          </Header>
-        }
-      >
-        <Tiles
-          value={draft?.camera.mode ?? null}
-          items={CAMERA_MODE_TILES.map((t) => ({ ...t, disabled: isLoading }))}
-          onChange={({ detail }) => updateCamera(detail.value)}
-        />
-      </Container>
+      {cameraTiles.length >= 3 && (
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="Controls which camera driver is used to capture the video feed."
+            >
+              Camera Mode
+            </Header>
+          }
+        >
+          <Tiles
+            value={draft?.camera.mode ?? null}
+            items={cameraTiles.map((t) => ({ ...t, disabled: isLoading }))}
+            onChange={({ detail }) => updateCamera(detail.value)}
+          />
+        </Container>
+      )}
 
-      <Container
-        header={
-          <Header
-            variant="h2"
-            description="Selects the hardware component that runs the neural network model during autonomous driving."
-          >
-            Inference Engine
-          </Header>
-        }
-      >
-        <Tiles
-          value={currentInferenceTileValue}
-          items={inferenceTiles.map((t) => ({ ...t, disabled: isLoading }))}
-          onChange={({ detail }) => updateInference(detail.value)}
-        />
-      </Container>
+      {inferenceTiles.length >= 3 && (
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="Selects the hardware component that runs the neural network model during autonomous driving."
+            >
+              Inference Engine
+            </Header>
+          }
+        >
+          <Tiles
+            value={currentInferenceTileValue}
+            items={inferenceTiles.map((t) => ({ ...t, disabled: isLoading }))}
+            onChange={({ detail }) => updateInference(detail.value)}
+          />
+        </Container>
+      )}
 
-      <Container
-        header={
-          <Header
-            variant="h2"
-            description="Selects the drivetrain type. Change this only if you have modified the car hardware."
-          >
-            Steering Mode
-          </Header>
-        }
-      >
-        <Tiles
-          value={draft?.steering.mode ?? null}
-          items={STEERING_MODE_TILES.map((t) => ({ ...t, disabled: isLoading }))}
-          onChange={({ detail }) => updateSteering(detail.value)}
-        />
-      </Container>
+      {steeringTiles.length >= 2 && (
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="Selects the drivetrain type. Change this only if you have modified the car hardware."
+            >
+              Steering Mode
+            </Header>
+          }
+        >
+          <Tiles
+            value={draft?.steering.mode ?? null}
+            items={steeringTiles.map((t) => ({ ...t, disabled: isLoading }))}
+            onChange={({ detail }) => updateSteering(detail.value)}
+          />
+        </Container>
+      )}
 
       <Box float="right">
         <SpaceBetween direction="horizontal" size="xs">

--- a/website/src/components/settings/car-config-container.tsx
+++ b/website/src/components/settings/car-config-container.tsx
@@ -57,9 +57,9 @@ function matchCI(value: string | null | undefined, options: string[], fallback: 
 }
 
 const LOGGING_MODE_TILES: TilesProps.TilesDefinition[] = [
-  { value: "Never", label: "Never", description: "Logs are not collected" },
-  { value: "USBOnly", label: "USB only", description: "Logs saved to a connected USB drive only" },
   { value: "Always", label: "Always", description: "Logs saved regardless of USB drive presence" },
+  { value: "USBOnly", label: "USB only", description: "Logs saved to a connected USB drive only" },
+  { value: "Never", label: "Never", description: "Logs are not collected" },
 ];
 
 const LOGGING_PROVIDER_TILES: TilesProps.TilesDefinition[] = [
@@ -380,7 +380,7 @@ export const CarConfigContainer = () => {
           {(capabilities?.logging_providers?.length ?? 0) > 1 && (
             <div>
               <Header variant="h3" description="Storage format used when writing ROS bag files.">
-                Provider
+                Storage Provider
               </Header>
               <Tiles
                 value={draft?.logging.provider ?? null}

--- a/website/src/components/settings/car-config-container.tsx
+++ b/website/src/components/settings/car-config-container.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import {
   Alert,
+  Badge,
   Box,
   Button,
   Container,
@@ -25,6 +26,9 @@ interface CarConfig {
     engine: string;
     device: string;
   };
+  steering: {
+    mode: string;
+  };
 }
 
 interface Capabilities {
@@ -33,12 +37,13 @@ interface Capabilities {
   logging_providers: string[];
   inference_engines: string[];
   inference_devices: Record<string, string[]>;
+  steering_modes: string[];
 }
 
 interface CarConfigResponse {
   success: boolean;
   config: CarConfig;
-  capabilities: Capabilities;
+  capabilities?: Capabilities;
   reason?: string;
 }
 
@@ -55,6 +60,24 @@ const LOGGING_MODE_TILES: TilesProps.TilesDefinition[] = [
   { value: "Never", label: "Never", description: "Logs are not collected" },
   { value: "USBOnly", label: "USB only", description: "Logs saved to a connected USB drive only" },
   { value: "Always", label: "Always", description: "Logs saved regardless of USB drive presence" },
+];
+
+const STEERING_MODE_TILES: TilesProps.TilesDefinition[] = [
+  {
+    value: "servo",
+    label: "Servo",
+    description: "Standard DeepRacer servo and ESC drivetrain",
+  },
+  {
+    value: "diffdrive",
+    label: (
+      <SpaceBetween direction="horizontal" size="xs">
+        <span>Differential Drive</span>
+        <Badge color="blue">Beta</Badge>
+      </SpaceBetween>
+    ),
+    description: "Direct motor control via the diff-drive package",
+  },
 ];
 
 const CAMERA_MODE_TILES: TilesProps.TilesDefinition[] = [
@@ -189,9 +212,17 @@ export const CarConfigContainer = () => {
           engine: normEngine,
           device: matchCI(cfg.inference.device, devices, "auto"),
         },
+        steering: {
+          ...cfg.steering,
+          mode: matchCI(
+            cfg.steering?.mode,
+            STEERING_MODE_TILES.map((t) => t.value),
+            "servo"
+          ),
+        },
       };
       setConfig(withDefaults);
-      setCapabilities(caps);
+      setCapabilities(caps ?? null);
       setDraft(withDefaults);
     }
     setIsLoading(false);
@@ -208,8 +239,7 @@ export const CarConfigContainer = () => {
     setSaveSuccess(false);
     setSaveError(null);
 
-    const payload = { ...draft, logging: { ...draft.logging, provider: "sqlite3" } };
-    const response = await ApiHelper.post<CarConfigResponse>("car_config", payload);
+    const response = await ApiHelper.post<CarConfigResponse>("car_config", draft);
     if (response?.success) {
       const cfg = response.config;
       const caps = capabilities;
@@ -239,6 +269,14 @@ export const CarConfigContainer = () => {
           engine: normEngine,
           device: matchCI(cfg.inference.device, devices, "auto"),
         },
+        steering: {
+          ...cfg.steering,
+          mode: matchCI(
+            cfg.steering?.mode,
+            STEERING_MODE_TILES.map((t) => t.value),
+            "servo"
+          ),
+        },
       };
       setConfig(withDefaults);
       setDraft(withDefaults);
@@ -258,6 +296,10 @@ export const CarConfigContainer = () => {
 
   const updateCamera = (value: string) => {
     setDraft((prev) => prev && { ...prev, camera: { ...prev.camera, mode: value } });
+  };
+
+  const updateSteering = (value: string) => {
+    setDraft((prev) => prev && { ...prev, steering: { mode: value } });
   };
 
   // ── Derived tile data ────────────────────────────────────────────────────────
@@ -335,6 +377,23 @@ export const CarConfigContainer = () => {
           value={currentInferenceTileValue}
           items={inferenceTiles.map((t) => ({ ...t, disabled: isLoading }))}
           onChange={({ detail }) => updateInference(detail.value)}
+        />
+      </Container>
+
+      <Container
+        header={
+          <Header
+            variant="h2"
+            description="Selects the drivetrain type. Change this only if you have modified the car hardware."
+          >
+            Steering Mode
+          </Header>
+        }
+      >
+        <Tiles
+          value={draft?.steering.mode ?? null}
+          items={STEERING_MODE_TILES.map((t) => ({ ...t, disabled: isLoading }))}
+          onChange={({ detail }) => updateSteering(detail.value)}
         />
       </Container>
 

--- a/website/src/test/unit/settings/car-config-container.test.tsx
+++ b/website/src/test/unit/settings/car-config-container.test.tsx
@@ -75,7 +75,7 @@ describe("CarConfigContainer", () => {
       expect(containers.length).toBe(4);
 
       const headerTexts = containers.map((c) => c.findHeader()?.getElement().textContent ?? "");
-      expect(headerTexts.some((t) => t.includes("Logging Mode"))).toBe(true);
+      expect(headerTexts.some((t) => t.includes("Logging"))).toBe(true);
       expect(headerTexts.some((t) => t.includes("Camera Mode"))).toBe(true);
       expect(headerTexts.some((t) => t.includes("Inference Engine"))).toBe(true);
       expect(headerTexts.some((t) => t.includes("Steering Mode"))).toBe(true);
@@ -104,7 +104,7 @@ describe("CarConfigContainer", () => {
       // Each section is now a Container with a header (no longer FormFields)
       const containers = wrapper.findAllContainers();
       const headerTexts = containers.map((c) => c.findHeader()?.getElement().textContent ?? "");
-      expect(headerTexts.some((t) => t.includes("Logging Mode"))).toBe(true);
+      expect(headerTexts.some((t) => t.includes("Logging"))).toBe(true);
       expect(headerTexts.some((t) => t.includes("Camera Mode"))).toBe(true);
       expect(headerTexts.some((t) => t.includes("Inference Engine"))).toBe(true);
       expect(headerTexts.some((t) => t.includes("Steering Mode"))).toBe(true);
@@ -157,6 +157,45 @@ describe("CarConfigContainer", () => {
 
       expect(screen.getByRole("radio", { name: /Servo/ })).toBeInTheDocument();
       expect(screen.getByRole("radio", { name: /Differential Drive/ })).toBeInTheDocument();
+    });
+
+    it("hides the logging Provider sub-section when only one provider is available", async () => {
+      mockApiHelper.get.mockResolvedValue(mockCarConfigResponse); // logging_providers: ["sqlite3"]
+
+      await act(async () => render(<CarConfigContainer />));
+      await waitFor(() => expect(mockApiHelper.get).toHaveBeenCalledWith("car_config"));
+
+      expect(screen.queryByRole("radio", { name: /SQLite3/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole("radio", { name: /MCAP/ })).not.toBeInTheDocument();
+    });
+
+    it("shows the logging Provider sub-section when multiple providers are available", async () => {
+      mockApiHelper.get.mockResolvedValue({
+        ...mockCarConfigResponse,
+        capabilities: { ...mockCapabilities, logging_providers: ["sqlite3", "mcap"] },
+      });
+
+      await act(async () => render(<CarConfigContainer />));
+      await waitFor(() => expect(mockApiHelper.get).toHaveBeenCalledWith("car_config"));
+
+      expect(screen.getByRole("radio", { name: /SQLite3/ })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: /MCAP/ })).toBeInTheDocument();
+    });
+
+    it("hides the Steering Mode container when only one steering mode is available", async () => {
+      mockApiHelper.get.mockResolvedValue({
+        ...mockCarConfigResponse,
+        capabilities: { ...mockCapabilities, steering_modes: ["servo"] },
+      });
+
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+      await waitFor(() => expect(mockApiHelper.get).toHaveBeenCalledWith("car_config"));
+
+      const headerTexts = wrapper
+        .findAllContainers()
+        .map((c) => c.findHeader()?.getElement().textContent ?? "");
+      expect(headerTexts.some((t) => t.includes("Steering Mode"))).toBe(false);
     });
 
     it("builds inference tiles including multi-device OV options from capabilities", async () => {
@@ -285,6 +324,24 @@ describe("CarConfigContainer", () => {
 
       expect(findButton(wrapper, "Save")?.getElement()).not.toBeDisabled();
     });
+    it("enables Save button after changing the logging provider", async () => {
+      mockApiHelper.get.mockResolvedValue({
+        ...mockCarConfigResponse,
+        capabilities: { ...mockCapabilities, logging_providers: ["sqlite3", "mcap"] },
+      });
+
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+
+      await waitFor(() => expect(mockApiHelper.get).toHaveBeenCalledWith("car_config"));
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("radio", { name: /MCAP/ }));
+      });
+
+      expect(findButton(wrapper, "Save")?.getElement()).not.toBeDisabled();
+    });
+
     it("enables Save button after changing the steering mode", async () => {
       mockApiHelper.get.mockResolvedValue(mockCarConfigResponse);
 
@@ -332,6 +389,39 @@ describe("CarConfigContainer", () => {
           "car_config",
           expect.objectContaining({
             logging: expect.objectContaining({ mode: "Always", provider: "sqlite3" }),
+          })
+        );
+      });
+    });
+
+    it("sends the updated logging provider in the save payload", async () => {
+      mockApiHelper.get.mockResolvedValue({
+        ...mockCarConfigResponse,
+        capabilities: { ...mockCapabilities, logging_providers: ["sqlite3", "mcap"] },
+      });
+      mockApiHelper.post.mockResolvedValue({
+        success: true,
+        config: { ...mockConfig, logging: { mode: "Never", provider: "mcap" } },
+      });
+
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+
+      await waitFor(() => expect(mockApiHelper.get).toHaveBeenCalledWith("car_config"));
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("radio", { name: /MCAP/ }));
+      });
+
+      await act(async () => {
+        findButton(wrapper, "Save")?.click();
+      });
+
+      await waitFor(() => {
+        expect(mockApiHelper.post).toHaveBeenCalledWith(
+          "car_config",
+          expect.objectContaining({
+            logging: expect.objectContaining({ provider: "mcap" }),
           })
         );
       });

--- a/website/src/test/unit/settings/car-config-container.test.tsx
+++ b/website/src/test/unit/settings/car-config-container.test.tsx
@@ -26,12 +26,14 @@ const mockCapabilities = {
     TFLITE: ["CPU"],
     OV: ["CPU", "GPU", "MYRIAD"],
   },
+  steering_modes: ["servo", "diffdrive"],
 };
 
 const mockConfig = {
   logging: { mode: "Never", provider: "sqlite3" },
   camera: { mode: "auto" },
   inference: { engine: "auto", device: "auto" },
+  steering: { mode: "servo" },
 };
 
 const mockCarConfigResponse = {
@@ -61,7 +63,7 @@ describe("CarConfigContainer", () => {
   // ── Rendering ──────────────────────────────────────────────────────────────
 
   describe("Component Rendering", () => {
-    it("renders three containers with section headers", async () => {
+    it("renders four containers with section headers", async () => {
       mockApiHelper.get.mockResolvedValue(mockCarConfigResponse);
 
       const { container } = await act(async () => render(<CarConfigContainer />));
@@ -70,12 +72,13 @@ describe("CarConfigContainer", () => {
       await waitFor(() => expect(mockApiHelper.get).toHaveBeenCalledWith("car_config"));
 
       const containers = wrapper.findAllContainers();
-      expect(containers.length).toBe(3);
+      expect(containers.length).toBe(4);
 
       const headerTexts = containers.map((c) => c.findHeader()?.getElement().textContent ?? "");
       expect(headerTexts.some((t) => t.includes("Logging Mode"))).toBe(true);
       expect(headerTexts.some((t) => t.includes("Camera Mode"))).toBe(true);
       expect(headerTexts.some((t) => t.includes("Inference Engine"))).toBe(true);
+      expect(headerTexts.some((t) => t.includes("Steering Mode"))).toBe(true);
     });
 
     it("renders Refresh and Save buttons in the header", async () => {
@@ -90,7 +93,7 @@ describe("CarConfigContainer", () => {
       expect(findButton(wrapper, "Save")).toBeTruthy();
     });
 
-    it("renders sections for Logging Mode, Camera Mode, and Inference Engine", async () => {
+    it("renders sections for Logging Mode, Camera Mode, Inference Engine, and Steering Mode", async () => {
       mockApiHelper.get.mockResolvedValue(mockCarConfigResponse);
 
       const { container } = await act(async () => render(<CarConfigContainer />));
@@ -104,6 +107,7 @@ describe("CarConfigContainer", () => {
       expect(headerTexts.some((t) => t.includes("Logging Mode"))).toBe(true);
       expect(headerTexts.some((t) => t.includes("Camera Mode"))).toBe(true);
       expect(headerTexts.some((t) => t.includes("Inference Engine"))).toBe(true);
+      expect(headerTexts.some((t) => t.includes("Steering Mode"))).toBe(true);
     });
 
     it("Save button is disabled when config is unchanged (not dirty)", async () => {
@@ -142,6 +146,17 @@ describe("CarConfigContainer", () => {
       expect(screen.getAllByRole("radio", { name: /Auto/ }).length).toBeGreaterThanOrEqual(2);
       expect(screen.getByRole("radio", { name: /Legacy \(V4L2\)/ })).toBeInTheDocument();
       expect(screen.getByRole("radio", { name: /Modern \(libcamera\)/ })).toBeInTheDocument();
+    });
+
+    it("displays all steering mode tile options", async () => {
+      mockApiHelper.get.mockResolvedValue(mockCarConfigResponse);
+
+      await act(async () => render(<CarConfigContainer />));
+
+      await waitFor(() => expect(mockApiHelper.get).toHaveBeenCalledWith("car_config"));
+
+      expect(screen.getByRole("radio", { name: /Servo/ })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: /Differential Drive/ })).toBeInTheDocument();
     });
 
     it("builds inference tiles including multi-device OV options from capabilities", async () => {
@@ -270,6 +285,21 @@ describe("CarConfigContainer", () => {
 
       expect(findButton(wrapper, "Save")?.getElement()).not.toBeDisabled();
     });
+    it("enables Save button after changing the steering mode", async () => {
+      mockApiHelper.get.mockResolvedValue(mockCarConfigResponse);
+
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+
+      await waitFor(() => expect(mockApiHelper.get).toHaveBeenCalledWith("car_config"));
+
+      // Current is "servo" → switch to "diffdrive"
+      await act(async () => {
+        fireEvent.click(screen.getByRole("radio", { name: /Differential Drive/ }));
+      });
+
+      expect(findButton(wrapper, "Save")?.getElement()).not.toBeDisabled();
+    });
   });
 
   // ── Save ───────────────────────────────────────────────────────────────────
@@ -280,7 +310,6 @@ describe("CarConfigContainer", () => {
       mockApiHelper.post.mockResolvedValue({
         success: true,
         config: { ...mockConfig, logging: { mode: "Always", provider: "sqlite3" } },
-        capabilities: mockCapabilities,
       });
 
       const { container } = await act(async () => render(<CarConfigContainer />));
@@ -308,12 +337,11 @@ describe("CarConfigContainer", () => {
       });
     });
 
-    it("always sends provider: sqlite3 in the save payload", async () => {
+    it("sends the steering mode in the save payload", async () => {
       mockApiHelper.get.mockResolvedValue(mockCarConfigResponse);
       mockApiHelper.post.mockResolvedValue({
         success: true,
-        config: mockConfig,
-        capabilities: mockCapabilities,
+        config: { ...mockConfig, steering: { mode: "diffdrive" } },
       });
 
       const { container } = await act(async () => render(<CarConfigContainer />));
@@ -322,7 +350,7 @@ describe("CarConfigContainer", () => {
       await waitFor(() => expect(mockApiHelper.get).toHaveBeenCalledWith("car_config"));
 
       await act(async () => {
-        fireEvent.click(screen.getByRole("radio", { name: /Always/ }));
+        fireEvent.click(screen.getByRole("radio", { name: /Differential Drive/ }));
       });
 
       await act(async () => {
@@ -333,7 +361,7 @@ describe("CarConfigContainer", () => {
         expect(mockApiHelper.post).toHaveBeenCalledWith(
           "car_config",
           expect.objectContaining({
-            logging: expect.objectContaining({ provider: "sqlite3" }),
+            steering: { mode: "diffdrive" },
           })
         );
       });
@@ -344,7 +372,6 @@ describe("CarConfigContainer", () => {
       mockApiHelper.post.mockResolvedValue({
         success: true,
         config: { ...mockConfig, logging: { mode: "Always", provider: "sqlite3" } },
-        capabilities: mockCapabilities,
       });
 
       const { container } = await act(async () => render(<CarConfigContainer />));
@@ -376,7 +403,6 @@ describe("CarConfigContainer", () => {
       mockApiHelper.post.mockResolvedValue({
         success: true,
         config: savedConfig,
-        capabilities: mockCapabilities,
       });
 
       const { container } = await act(async () => render(<CarConfigContainer />));


### PR DESCRIPTION
This pull request adds support for configuring the steering mode of the car in the settings UI, allowing users to select between "Servo" and "Differential Drive" drivetrains. The changes include updates to the UI, data model, and unit tests to support the new steering mode option.

**UI and Data Model Enhancements:**

* Added a new "Steering Mode" section to the car configuration UI, allowing users to choose between "Servo" and "Differential Drive" options, with the latter marked as Beta. (`car-config-container.tsx`)
* Extended the `CarConfig` and `Capabilities` interfaces to include the new `steering` and `steering_modes` fields, and updated related logic to handle these properties. (`car-config-container.tsx`) [[1]](diffhunk://#diff-e79a165c942806c30548e832cdd87bb5d40fafb94ff79f3f061a9986953909afR29-R31) [[2]](diffhunk://#diff-e79a165c942806c30548e832cdd87bb5d40fafb94ff79f3f061a9986953909afR40-R46)

**State Management and API Integration:**

* Updated state initialization and save logic to correctly handle the new steering mode, ensuring the selected mode is persisted and restored. (`car-config-container.tsx`) [[1]](diffhunk://#diff-e79a165c942806c30548e832cdd87bb5d40fafb94ff79f3f061a9986953909afR215-R225) [[2]](diffhunk://#diff-e79a165c942806c30548e832cdd87bb5d40fafb94ff79f3f061a9986953909afR272-R279) [[3]](diffhunk://#diff-e79a165c942806c30548e832cdd87bb5d40fafb94ff79f3f061a9986953909afR301-R304) [[4]](diffhunk://#diff-e79a165c942806c30548e832cdd87bb5d40fafb94ff79f3f061a9986953909afL211-R242)

**Testing Improvements:**

* Enhanced unit tests to verify rendering of the new "Steering Mode" section, the presence of both steering mode options, and correct save behavior when the steering mode is changed. (`car-config-container.test.tsx`) [[1]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecL64-R66) [[2]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecL73-R81) [[3]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecL93-R96) [[4]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecR110) [[5]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecR151-R161) [[6]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecR286-R300) [[7]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecL311-R344) [[8]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecL325-R353) [[9]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecL336-R364)
* Updated mock data to include steering mode information and adjusted tests to validate that the correct payload is sent to the API. (`car-config-container.test.tsx`) [[1]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecR29-R36) [[2]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecL283) [[3]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecL347) [[4]](diffhunk://#diff-6187a5871cd2cd9c5dea0430393bd77b23cef18c408a28c9684f5a250f482cecL379)