### PR TITLE
feat: Add camera rotation (orientation) control to settings UI

### DIFF
--- a/website/src/common/hooks/use-car-config.ts
+++ b/website/src/common/hooks/use-car-config.ts
@@ -12,6 +12,7 @@ export interface CarConfig {
   };
   camera: {
     mode: string;
+    orientation?: number;
     enable_gray_overlay?: boolean;
   };
   inference: {
@@ -25,6 +26,7 @@ export interface CarConfig {
 
 export interface Capabilities {
   camera_modes: string[];
+  camera_orientations?: number[];
   logging_modes: string[];
   logging_providers: string[];
   inference_engines: string[];

--- a/website/src/components/settings/car-config-container.tsx
+++ b/website/src/components/settings/car-config-container.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   Button,
   Container,
-  FormField,
   Header,
   SpaceBetween,
   Tiles,
@@ -171,6 +170,7 @@ export const CarConfigContainer = () => {
       camera: {
         ...cfg.camera,
         mode: matchCI(cfg.camera.mode, CAMERA_MODE_TILES.map((t) => t.value), "auto"),
+        orientation: cfg.camera.orientation === 180 ? 180 : 0,
         enable_gray_overlay: cfg.camera.enable_gray_overlay ?? false,
       },
       inference: {
@@ -228,7 +228,23 @@ export const CarConfigContainer = () => {
   };
 
   const updateCamera = (value: string) => {
-    setDraft((prev) => prev && { ...prev, camera: { ...prev.camera, mode: value } });
+    setDraft((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        camera: {
+          ...prev.camera,
+          mode: value,
+          orientation: value === "modern" ? (prev.camera.orientation === 180 ? 180 : 0) : 0,
+        },
+      };
+    });
+  };
+
+  const updateCameraOrientation = (checked: boolean) => {
+    setDraft((prev) =>
+      prev && { ...prev, camera: { ...prev.camera, orientation: checked ? 180 : 0 } }
+    );
   };
 
   const updateGrayOverlay = (checked: boolean) => {
@@ -250,6 +266,9 @@ export const CarConfigContainer = () => {
   const cameraTiles = CAMERA_MODE_TILES.filter(
     (t) => t.value === "auto" || capabilities?.camera_modes?.includes(t.value)
   );
+  const isCameraOrientationSupported = capabilities?.camera_orientations?.includes(180) === true;
+  const showCameraOrientationControl =
+    draft?.camera.mode === "modern" && isCameraOrientationSupported;
 
   const steeringTiles = STEERING_MODE_TILES.filter((t) =>
     capabilities?.steering_modes?.includes(t.value)
@@ -337,10 +356,10 @@ export const CarConfigContainer = () => {
               </div>
             )}
             {capabilities?.gray_overlay && (
-              <FormField
-                label="Gray overlay"
-                description="Apply a gray fade over the top of the camera image to reduce background influence during inference."
-              >
+              <div>
+                <Header variant="h3" description="Apply a gray fade over the top of the camera image to reduce background influence during inference.">
+                  Gray overlay
+                </Header>
                 <Toggle
                   checked={draft?.camera.enable_gray_overlay ?? false}
                   disabled={isLoading}
@@ -348,7 +367,21 @@ export const CarConfigContainer = () => {
                 >
                   {draft?.camera.enable_gray_overlay ? "Enabled" : "Disabled"}
                 </Toggle>
-              </FormField>
+              </div>
+            )}
+            {showCameraOrientationControl && (
+              <div>
+                <Header variant="h3" description="Rotate camera feed by 180 degrees (libcamera only).">
+                  Camera rotation
+                </Header>
+                <Toggle
+                  checked={(draft?.camera.orientation ?? 0) === 180}
+                  disabled={isLoading}
+                  onChange={({ detail }) => updateCameraOrientation(detail.checked)}
+                >
+                  {(draft?.camera.orientation ?? 0) === 180 ? "180 deg" : "0 deg"}
+                </Toggle>
+              </div>
             )}
           </SpaceBetween>
         </Container>

--- a/website/src/test/integration/system-unavailable-page.test.tsx
+++ b/website/src/test/integration/system-unavailable-page.test.tsx
@@ -26,14 +26,11 @@ describe("SystemUnavailablePage Integration", () => {
 
   // Spy on setInterval/clearInterval so we can trigger polls manually
   // without any fake-timer infrastructure that conflicts with React 18.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let activeCallback: (() => Promise<void>) | null = null;
   let activeIntervalId: number = 0;
   let idCounter = 1000;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let setIntervalSpy: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let clearIntervalSpy: any;
+  let setIntervalSpy: ReturnType<typeof vi.spyOn>;
+  let clearIntervalSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -44,8 +41,7 @@ describe("SystemUnavailablePage Integration", () => {
 
     setIntervalSpy = vi
       .spyOn(globalThis, "setInterval")
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation((callback: any) => {
+      .mockImplementation((callback: Parameters<typeof setInterval>[0]) => {
         const id = idCounter++;
         activeCallback = callback as () => Promise<void>;
         activeIntervalId = id;
@@ -54,8 +50,7 @@ describe("SystemUnavailablePage Integration", () => {
 
     clearIntervalSpy = vi
       .spyOn(globalThis, "clearInterval")
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation((id: any) => {
+      .mockImplementation((id: Parameters<typeof clearInterval>[0]) => {
         if ((id as number) === activeIntervalId) {
           activeCallback = null;
         }

--- a/website/src/test/unit/settings/car-config-container.test.tsx
+++ b/website/src/test/unit/settings/car-config-container.test.tsx
@@ -29,6 +29,7 @@ const mockApiHelper = vi.mocked(ApiHelper);
 
 const mockCapabilities = {
   camera_modes: ["auto", "legacy", "modern"],
+  camera_orientations: [0, 180],
   logging_modes: ["Never", "USBOnly", "Always"],
   logging_providers: ["sqlite3"],
   inference_engines: ["TFLITE", "OV"],
@@ -41,7 +42,7 @@ const mockCapabilities = {
 
 const mockConfig = {
   logging: { mode: "Never", provider: "sqlite3" },
-  camera: { mode: "auto" },
+  camera: { mode: "auto", orientation: 0 },
   inference: { engine: "auto", device: "auto" },
   steering: { mode: "servo" },
 };
@@ -183,6 +184,45 @@ describe("CarConfigContainer", () => {
       expect(screen.getByRole("radio", { name: /OpenVINO.*CPU/i })).toBeInTheDocument();
       expect(screen.getByRole("radio", { name: /OpenVINO.*GPU/i })).toBeInTheDocument();
       expect(screen.getByRole("radio", { name: /Myriad X/i })).toBeInTheDocument();
+    });
+
+    it("hides camera rotation control when camera mode is auto", async () => {
+      await act(async () => render(<CarConfigContainer />));
+
+      expect(screen.queryByText("Camera rotation")).not.toBeInTheDocument();
+    });
+
+    it("shows camera rotation control when camera mode is modern", async () => {
+      mockUseCarConfig.mockReturnValue({
+        ...defaultContextValue(),
+        config: {
+          ...mockConfig,
+          camera: { mode: "modern", orientation: 0 },
+        },
+      });
+
+      await act(async () => render(<CarConfigContainer />));
+
+      expect(screen.getByText("Camera rotation")).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: /0 deg/ })).toBeInTheDocument();
+    });
+
+    it("hides camera rotation control when capability is not available", async () => {
+      mockUseCarConfig.mockReturnValue({
+        ...defaultContextValue(),
+        config: {
+          ...mockConfig,
+          camera: { mode: "modern", orientation: 0 },
+        },
+        capabilities: {
+          ...mockCapabilities,
+          camera_orientations: [],
+        },
+      });
+
+      await act(async () => render(<CarConfigContainer />));
+
+      expect(screen.queryByText("Camera rotation")).not.toBeInTheDocument();
     });
   });
 
@@ -379,6 +419,74 @@ describe("CarConfigContainer", () => {
           "car_config",
           expect.objectContaining({
             steering: { mode: "diffdrive" },
+          })
+        );
+      });
+    });
+
+    it("sends camera.orientation 180 when camera rotation is enabled", async () => {
+      mockUseCarConfig.mockReturnValue({
+        ...defaultContextValue(),
+        config: {
+          ...mockConfig,
+          camera: { mode: "modern", orientation: 0 },
+        },
+      });
+      mockApiHelper.post.mockResolvedValue({
+        success: true,
+        config: { ...mockConfig, camera: { mode: "modern", orientation: 180 } },
+      });
+
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("checkbox", { name: /0 deg/ }));
+      });
+
+      await act(async () => {
+        findButton(wrapper, "Save")?.click();
+      });
+
+      await waitFor(() => {
+        expect(mockApiHelper.post).toHaveBeenCalledWith(
+          "car_config",
+          expect.objectContaining({
+            camera: expect.objectContaining({ orientation: 180 }),
+          })
+        );
+      });
+    });
+
+    it("resets camera.orientation to 0 when switching away from modern mode", async () => {
+      mockUseCarConfig.mockReturnValue({
+        ...defaultContextValue(),
+        config: {
+          ...mockConfig,
+          camera: { mode: "modern", orientation: 180 },
+        },
+      });
+      mockApiHelper.post.mockResolvedValue({
+        success: true,
+        config: { ...mockConfig, camera: { mode: "legacy", orientation: 0 } },
+      });
+
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("radio", { name: /Legacy/ }));
+      });
+
+      await act(async () => {
+        findButton(wrapper, "Save")?.click();
+      });
+
+      await waitFor(() => {
+        expect(mockApiHelper.post).toHaveBeenCalledWith(
+          "car_config",
+          expect.objectContaining({
+            camera: expect.objectContaining({ mode: "legacy", orientation: 0 }),
           })
         );
       });


### PR DESCRIPTION
## Summary

Adds a **Camera rotation** toggle to the Camera section of the Settings page, allowing users to rotate the camera feed by 180 degrees when using libcamera (modern mode).

## Changes

### `use-car-config.ts`
- Added optional `orientation` field to the `CarConfig.camera` interface
- Added optional `camera_orientations` field to the `Capabilities` interface

### `car-config-container.tsx`
- Normalises `camera.orientation` to `0` or `180` on load
- `updateCamera()` now resets orientation to `0` when switching away from modern mode
- New `updateCameraOrientation()` handler to toggle between `0` and `180` degrees
- Derives `isCameraOrientationSupported` from `capabilities.camera_orientations`
- Renders the **Camera rotation** toggle when `camera.mode === "modern"` and the capability is reported by the server
- Replaced `FormField` with `Header h3` for **Gray overlay** and the new **Camera rotation** control, matching the visual style of the **Mode** tile row

### `car-config-container.test.tsx`
- Added unit tests covering orientation rendering, toggling, and cleanup on mode switch
