### PR TITLE
feat: IMU safety stop UI — car config settings + SSE notifications

### DIFF
--- a/website/src/common/hooks/use-car-config.ts
+++ b/website/src/common/hooks/use-car-config.ts
@@ -22,6 +22,11 @@ export interface CarConfig {
   steering: {
     mode: string;
   };
+  imu: {
+    enabled: boolean;
+    crash_threshold_g: number;
+    pickup_threshold_g: number;
+  };
 }
 
 export interface Capabilities {
@@ -33,6 +38,9 @@ export interface Capabilities {
   inference_devices: Record<string, string[]>;
   steering_modes: string[];
   gray_overlay?: boolean;
+  imu?: boolean;
+  imu_crash_thresholds?: number[];
+  imu_pickup_thresholds?: number[];
 }
 
 export interface CarConfigResponse {

--- a/website/src/common/hooks/use-supported-apis.ts
+++ b/website/src/common/hooks/use-supported-apis.ts
@@ -8,6 +8,7 @@ interface SupportedApisState {
   isDeviceStatusSupported: boolean;
   isTimeApiSupported: boolean;
   isCarConfigSupported: boolean;
+  isEventsSupported: boolean;
   isLoading: boolean;
   hasError: boolean;
 }
@@ -28,6 +29,7 @@ export const useSupportedApisProvider = () => {
   const [isDeviceStatusSupported, setIsDeviceStatusSupported] = useState<boolean>(false);
   const [isTimeApiSupported, setIsTimeApiSupported] = useState<boolean>(false);
   const [isCarConfigSupported, setIsCarConfigSupported] = useState<boolean>(false);
+  const [isEventsSupported, setIsEventsSupported] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [hasError, setHasError] = useState<boolean>(false);
   const { isAuthenticated } = useAuth();
@@ -41,6 +43,7 @@ export const useSupportedApisProvider = () => {
       setIsLoading(false);
       setIsTimeApiSupported(false);
       setIsCarConfigSupported(false);
+      setIsEventsSupported(false);
       setHasError(false);
       return;
     }
@@ -59,8 +62,8 @@ export const useSupportedApisProvider = () => {
           setIsEmergencyStopSupported(response.apis_supported.includes("/api/emergency_stop"));
           setIsDeviceStatusSupported(response.apis_supported.includes("/api/get_device_status"));
           setIsTimeApiSupported(response.apis_supported.includes("/api/get_time"));
-          const carConfigSupported = response.apis_supported.includes("/api/car_config");
-          setIsCarConfigSupported(carConfigSupported);
+          setIsCarConfigSupported(response.apis_supported.includes("/api/car_config"));
+          setIsEventsSupported(response.apis_supported.includes("/api/events"));
           setHasError(false);
         } else if (isSubscribed) {
           setSupportedApis([]);
@@ -68,8 +71,9 @@ export const useSupportedApisProvider = () => {
           setIsDeviceStatusSupported(false);
           setIsTimeApiSupported(false);
           setIsCarConfigSupported(false);
+          setIsEventsSupported(false);
           setHasError(true);
-        }
+        } 
       } catch (error) {
         console.error("Error checking supported APIs:", error);
         if (isSubscribed) {
@@ -78,6 +82,7 @@ export const useSupportedApisProvider = () => {
           setIsDeviceStatusSupported(false);
           setIsTimeApiSupported(false);
           setIsCarConfigSupported(false);
+          setIsEventsSupported(false);
           setHasError(true);
         }
       } finally {
@@ -103,6 +108,7 @@ export const useSupportedApisProvider = () => {
     isDeviceStatusSupported,
     isTimeApiSupported,
     isCarConfigSupported,
+    isEventsSupported,
     isLoading,
     hasError,
   };

--- a/website/src/components/device-status-panel.tsx
+++ b/website/src/components/device-status-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import {
   Box,
   SplitPanel,
@@ -8,6 +8,7 @@ import {
   Grid,
 } from "@cloudscape-design/components";
 import { ApiHelper } from "../common/helpers/api-helper";
+import { useSupportedApis } from "../common/hooks/use-supported-apis";
 
 interface DeviceStatusProps {
   isInferenceRunning: boolean;
@@ -41,6 +42,7 @@ interface DeviceStatusResponse {
 }
 
 const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatusProps) => {
+  const { isEventsSupported } = useSupportedApis();
   // Define comparison types
   type ComparisonOperator = "gt" | "lt" | "gte" | "lte" | "eq";
 
@@ -425,6 +427,52 @@ const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatu
 
     return () => clearInterval(intervalId);
   }, []); // Remove updatesSinceInferenceStarted from dependency array
+
+  // Auto-dismiss timer ref for the IMU safety stop notification.
+  const imuDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Listen for IMU safety stop events via Server-Sent Events.
+  useEffect(() => {
+    if (!isEventsSupported) return;
+    const es = new EventSource("/api/events");
+
+    const dismissImuNotification = () =>
+      setNotifications((p) => p.filter((n) => n.id !== "imu-safety-stop"));
+
+    es.addEventListener("imu_stop", (e: MessageEvent) => {
+      const reason = JSON.parse(e.data) as string;
+      const label = reason === "crash" ? "Crash detected" : "Vehicle lifted";
+
+      // Reset the auto-dismiss timer on every new event.
+      if (imuDismissTimer.current) clearTimeout(imuDismissTimer.current);
+      imuDismissTimer.current = setTimeout(dismissImuNotification, 5000);
+
+      // Upsert the notification (replace if already showing so label stays current).
+      setNotifications((prev) => [
+        ...prev.filter((n) => n.id !== "imu-safety-stop"),
+        {
+          id: "imu-safety-stop",
+          type: "warning",
+          header: `IMU safety stop \u2014 ${label}`,
+          content: "The vehicle was automatically stopped by the IMU safety system.",
+          dismissible: true,
+          onDismiss: () => {
+            if (imuDismissTimer.current) clearTimeout(imuDismissTimer.current);
+            dismissImuNotification();
+          },
+        },
+      ]);
+    });
+
+    es.onerror = () => {
+      // EventSource will auto-reconnect on error; no action needed.
+    };
+
+    return () => {
+      es.close();
+      if (imuDismissTimer.current) clearTimeout(imuDismissTimer.current);
+    };
+  }, [isEventsSupported, setNotifications]);
 
   return (
     <SplitPanel header={"Car Health"} hidePreferencesButton={true} closeBehavior="collapse">

--- a/website/src/components/device-status-panel.tsx
+++ b/website/src/components/device-status-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import {
   Box,
   SplitPanel,
@@ -8,7 +8,6 @@ import {
   Grid,
 } from "@cloudscape-design/components";
 import { ApiHelper } from "../common/helpers/api-helper";
-import { useSupportedApis } from "../common/hooks/use-supported-apis";
 
 interface DeviceStatusProps {
   isInferenceRunning: boolean;
@@ -42,7 +41,6 @@ interface DeviceStatusResponse {
 }
 
 const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatusProps) => {
-  const { isEventsSupported } = useSupportedApis();
   // Define comparison types
   type ComparisonOperator = "gt" | "lt" | "gte" | "lte" | "eq";
 
@@ -427,52 +425,6 @@ const DeviceStatusPanel = ({ isInferenceRunning, setNotifications }: DeviceStatu
 
     return () => clearInterval(intervalId);
   }, []); // Remove updatesSinceInferenceStarted from dependency array
-
-  // Auto-dismiss timer ref for the IMU safety stop notification.
-  const imuDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Listen for IMU safety stop events via Server-Sent Events.
-  useEffect(() => {
-    if (!isEventsSupported) return;
-    const es = new EventSource("/api/events");
-
-    const dismissImuNotification = () =>
-      setNotifications((p) => p.filter((n) => n.id !== "imu-safety-stop"));
-
-    es.addEventListener("imu_stop", (e: MessageEvent) => {
-      const reason = JSON.parse(e.data) as string;
-      const label = reason === "crash" ? "Crash detected" : "Vehicle lifted";
-
-      // Reset the auto-dismiss timer on every new event.
-      if (imuDismissTimer.current) clearTimeout(imuDismissTimer.current);
-      imuDismissTimer.current = setTimeout(dismissImuNotification, 5000);
-
-      // Upsert the notification (replace if already showing so label stays current).
-      setNotifications((prev) => [
-        ...prev.filter((n) => n.id !== "imu-safety-stop"),
-        {
-          id: "imu-safety-stop",
-          type: "warning",
-          header: `IMU safety stop \u2014 ${label}`,
-          content: "The vehicle was automatically stopped by the IMU safety system.",
-          dismissible: true,
-          onDismiss: () => {
-            if (imuDismissTimer.current) clearTimeout(imuDismissTimer.current);
-            dismissImuNotification();
-          },
-        },
-      ]);
-    });
-
-    es.onerror = () => {
-      // EventSource will auto-reconnect on error; no action needed.
-    };
-
-    return () => {
-      es.close();
-      if (imuDismissTimer.current) clearTimeout(imuDismissTimer.current);
-    };
-  }, [isEventsSupported, setNotifications]);
 
   return (
     <SplitPanel header={"Car Health"} hidePreferencesButton={true} closeBehavior="collapse">

--- a/website/src/components/settings/car-config-container.tsx
+++ b/website/src/components/settings/car-config-container.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Container,
   Header,
+  Slider,
   SpaceBetween,
   Tiles,
   TilesProps,
@@ -187,6 +188,11 @@ export const CarConfigContainer = () => {
         mode: matchCI(cfg.logging.mode, LOGGING_MODE_TILES.map((t) => t.value), "Never"),
         provider: matchCI(cfg.logging.provider, LOGGING_PROVIDER_TILES.map((t) => t.value), "sqlite3"),
       },
+      imu: {
+        enabled: cfg.imu?.enabled ?? false,
+        crash_threshold_g: cfg.imu?.crash_threshold_g ?? 0,
+        pickup_threshold_g: cfg.imu?.pickup_threshold_g ?? 0,
+      },
     };
     setSavedConfig(withDefaults);
     // Reset draft to the refreshed config (Refresh button behaviour)
@@ -253,6 +259,23 @@ export const CarConfigContainer = () => {
 
   const updateSteering = (value: string) => {
     setDraft((prev) => prev && { ...prev, steering: { mode: value } });
+  };
+
+  const updateImuEnabled = (checked: boolean) => {
+    setDraft((prev) => prev && { ...prev, imu: { ...prev.imu, enabled: checked } });
+  };
+
+  // Index-based sliders: index 0 = Disabled, index N = Nth threshold value.
+  // This eliminates any intermediate invalid positions.
+  const IMU_CRASH_STEPS = [0, 1.5, 2.0, 2.5, 3.0];
+  const IMU_PICKUP_STEPS = [0, 0.5, 0.75, 0.95];
+
+  const updateImuCrash = (index: number) => {
+    setDraft((prev) => prev && { ...prev, imu: { ...prev.imu, crash_threshold_g: IMU_CRASH_STEPS[index] ?? 0 } });
+  };
+
+  const updateImuPickup = (index: number) => {
+    setDraft((prev) => prev && { ...prev, imu: { ...prev.imu, pickup_threshold_g: IMU_PICKUP_STEPS[index] ?? 0 } });
   };
 
   // ── Derived tile data ────────────────────────────────────────────────────────
@@ -422,6 +445,68 @@ export const CarConfigContainer = () => {
             items={steeringTiles.map((t) => ({ ...t, disabled: isLoading }))}
             onChange={({ detail }) => updateSteering(detail.value)}
           />
+        </Container>
+      )}
+
+      {capabilities?.imu && (
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="Configure the BMI160 IMU safety features. Changes take effect on next service restart."
+            >
+              IMU
+            </Header>
+          }
+        >
+          <SpaceBetween size="l">
+            <div>
+              <Header variant="h3" description="Enable the IMU node. Required for crash and pickup detection.">
+                Enable IMU
+              </Header>
+              <Toggle
+                checked={draft?.imu.enabled ?? false}
+                disabled={isLoading}
+                onChange={({ detail }) => updateImuEnabled(detail.checked)}
+              >
+                {draft?.imu.enabled ? "Enabled" : "Disabled"}
+              </Toggle>
+            </div>
+            {draft?.imu.enabled && (
+              <>
+                <div>
+                  <Header variant="h3" description="Stop the car when a high-G impact is detected. Set to Disabled to turn off.">
+                    Crash Detection
+                  </Header>
+                  <Slider
+                    value={IMU_CRASH_STEPS.indexOf(draft?.imu.crash_threshold_g ?? 0)}
+                    min={0}
+                    max={IMU_CRASH_STEPS.length - 1}
+                    step={1}
+                    referenceValues={IMU_CRASH_STEPS.map((_, i) => i)}
+                    disabled={isLoading}
+                    valueFormatter={(i) => i === 0 ? "Disabled" : `${IMU_CRASH_STEPS[i]} G`}
+                    onChange={({ detail }) => updateImuCrash(detail.value)}
+                  />
+                </div>
+                <div>
+                  <Header variant="h3" description="Stop the car when it is picked up or tipped over. Set to Disabled to turn off.">
+                    Pickup Detection
+                  </Header>
+                  <Slider
+                    value={IMU_PICKUP_STEPS.indexOf(draft?.imu.pickup_threshold_g ?? 0)}
+                    min={0}
+                    max={IMU_PICKUP_STEPS.length - 1}
+                    step={1}
+                    referenceValues={IMU_PICKUP_STEPS.map((_, i) => i)}
+                    disabled={isLoading}
+                    valueFormatter={(i) => i === 0 ? "Disabled" : `${IMU_PICKUP_STEPS[i]} G`}
+                    onChange={({ detail }) => updateImuPickup(detail.value)}
+                  />
+                </div>
+              </>
+            )}
+          </SpaceBetween>
         </Container>
       )}
 

--- a/website/src/pages/home.tsx
+++ b/website/src/pages/home.tsx
@@ -70,14 +70,61 @@ const HomePage = () => {
   const { isAuthenticated } = useAuth();
 
   // Split panel
-  const { isDeviceStatusSupported } = useSupportedApis();
-  const { isGrayOverlayEnabled } = useCarConfig();
+  const { isDeviceStatusSupported, isEventsSupported } = useSupportedApis();
+  const { isGrayOverlayEnabled, config } = useCarConfig();
   const [isSplitPanelOpen, setIsSplitPanelOpen] = useState(false);
   const [splitPanelSize, setSplitPanelSize] = useState(220);
 
   const [localFlashMessages, setLocalFlashMessages] = useState<FlashbarProps.MessageDefinition[]>(
     []
   );
+
+  // Auto-dismiss timer ref for the IMU safety stop notification.
+  const imuDismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Listen for IMU safety stop events via Server-Sent Events.
+  // Only active when IMU is enabled in config and the vehicle is running.
+  useEffect(() => {
+    if (!isEventsSupported || !config?.imu?.enabled || !isInferenceRunning) return;
+    const es = new EventSource("/api/events");
+
+    const dismissImuNotification = () =>
+      setLocalFlashMessages((p) => p.filter((n) => n.id !== "imu-safety-stop"));
+
+    es.addEventListener("imu_stop", (e: MessageEvent) => {
+      const reason = JSON.parse(e.data) as string;
+      const label = reason === "crash" ? "Crash detected" : "Vehicle lifted";
+
+      // Reset the auto-dismiss timer on every new event.
+      if (imuDismissTimer.current) clearTimeout(imuDismissTimer.current);
+      imuDismissTimer.current = setTimeout(dismissImuNotification, 5000);
+
+      // Upsert the notification so label stays current on repeat events.
+      setLocalFlashMessages((prev) => [
+        ...prev.filter((n) => n.id !== "imu-safety-stop"),
+        {
+          id: "imu-safety-stop",
+          type: "warning",
+          header: `IMU safety stop \u2014 ${label}`,
+          content: "The vehicle was automatically stopped by the IMU safety system.",
+          dismissible: true,
+          onDismiss: () => {
+            if (imuDismissTimer.current) clearTimeout(imuDismissTimer.current);
+            dismissImuNotification();
+          },
+        },
+      ]);
+    });
+
+    es.onerror = () => {
+      // EventSource will auto-reconnect on error; no action needed.
+    };
+
+    return () => {
+      es.close();
+      if (imuDismissTimer.current) clearTimeout(imuDismissTimer.current);
+    };
+  }, [isEventsSupported, config?.imu?.enabled, isInferenceRunning]);
 
   const SENSOR_STATUS_REFRESH_INTERVAL_MS = 15000; // 15 seconds
 

--- a/website/src/test/unit/global-header.test.tsx
+++ b/website/src/test/unit/global-header.test.tsx
@@ -113,6 +113,7 @@ describe("GlobalHeader", () => {
     isDeviceStatusSupported,
     isTimeApiSupported: false,
     isCarConfigSupported: false,
+    isEventsSupported: false,
     isLoading: false,
     hasError: false,
   });

--- a/website/src/test/unit/settings/car-config-container.test.tsx
+++ b/website/src/test/unit/settings/car-config-container.test.tsx
@@ -650,6 +650,139 @@ describe("CarConfigContainer", () => {
     });
   });
 
+  // ── IMU ────────────────────────────────────────────────────────────────────
+
+  describe("IMU section", () => {
+    const mockCapabilitiesWithImu = {
+      ...mockCapabilities,
+      imu: true,
+      imu_crash_thresholds: [0, 1.5, 2.0, 2.5, 3.0],
+      imu_pickup_thresholds: [0, 0.5, 0.75, 0.95],
+    };
+
+    const mockConfigWithImu = {
+      ...mockConfig,
+      imu: { enabled: false, crash_threshold_g: 0, pickup_threshold_g: 0 },
+    };
+
+    it("does not render the IMU container when capabilities.imu is false", async () => {
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+
+      const headerTexts = wrapper
+        .findAllContainers()
+        .map((c) => c.findHeader()?.getElement().textContent ?? "");
+      expect(headerTexts.some((t) => t.includes("IMU"))).toBe(false);
+    });
+
+    it("renders the IMU container when capabilities.imu is true", async () => {
+      mockUseCarConfig.mockReturnValue({
+        ...defaultContextValue(),
+        config: mockConfigWithImu,
+        capabilities: mockCapabilitiesWithImu,
+      });
+
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+
+      const headerTexts = wrapper
+        .findAllContainers()
+        .map((c) => c.findHeader()?.getElement().textContent ?? "");
+      expect(headerTexts.some((t) => t.includes("IMU"))).toBe(true);
+    });
+
+    it("shows Enable IMU toggle defaulting to off when config.imu.enabled is false", async () => {
+      mockUseCarConfig.mockReturnValue({
+        ...defaultContextValue(),
+        config: mockConfigWithImu,
+        capabilities: mockCapabilitiesWithImu,
+      });
+
+      await act(async () => render(<CarConfigContainer />));
+
+      expect(screen.getByText("Enable IMU")).toBeInTheDocument();
+      expect(screen.getByText("Disabled")).toBeInTheDocument();
+    });
+
+    it("hides crash and pickup sliders when IMU is disabled", async () => {
+      mockUseCarConfig.mockReturnValue({
+        ...defaultContextValue(),
+        config: mockConfigWithImu,
+        capabilities: mockCapabilitiesWithImu,
+      });
+
+      await act(async () => render(<CarConfigContainer />));
+
+      expect(screen.queryByText("Crash Detection")).not.toBeInTheDocument();
+      expect(screen.queryByText("Pickup Detection")).not.toBeInTheDocument();
+    });
+
+    it("shows crash and pickup sliders after toggling IMU on", async () => {
+      mockUseCarConfig.mockReturnValue({
+        ...defaultContextValue(),
+        config: mockConfigWithImu,
+        capabilities: mockCapabilitiesWithImu,
+      });
+
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+
+      await act(async () => {
+        wrapper.findToggle()?.findNativeInput().click();
+      });
+
+      expect(screen.getByText("Crash Detection")).toBeInTheDocument();
+      expect(screen.getByText("Pickup Detection")).toBeInTheDocument();
+    });
+
+    it("enables Save after toggling IMU on", async () => {
+      mockUseCarConfig.mockReturnValue({
+        ...defaultContextValue(),
+        config: mockConfigWithImu,
+        capabilities: mockCapabilitiesWithImu,
+      });
+
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+
+      await act(async () => {
+        wrapper.findToggle()?.findNativeInput().click();
+      });
+
+      expect(findButton(wrapper, "Save")?.getElement()).not.toBeDisabled();
+    });
+
+    it("sends imu section in save payload when IMU is enabled", async () => {
+      mockUseCarConfig.mockReturnValue({
+        ...defaultContextValue(),
+        config: mockConfigWithImu,
+        capabilities: mockCapabilitiesWithImu,
+      });
+      mockApiHelper.post.mockResolvedValue({ success: true, config: mockConfigWithImu });
+
+      const { container } = await act(async () => render(<CarConfigContainer />));
+      const wrapper = createWrapper(container);
+
+      // Toggle IMU on
+      await act(async () => {
+        wrapper.findToggle()?.findNativeInput().click();
+      });
+
+      await act(async () => {
+        findButton(wrapper, "Save")?.click();
+      });
+
+      await waitFor(() => {
+        expect(mockApiHelper.post).toHaveBeenCalledWith(
+          "car_config",
+          expect.objectContaining({
+            imu: expect.objectContaining({ enabled: true }),
+          })
+        );
+      });
+    });
+  });
+
   // ── Refresh ────────────────────────────────────────────────────────────────
 
   describe("Refresh behaviour", () => {

--- a/website/src/test/unit/use-supported-apis.test.tsx
+++ b/website/src/test/unit/use-supported-apis.test.tsx
@@ -37,6 +37,7 @@ interface SupportedApisState {
   isDeviceStatusSupported: boolean;
   isTimeApiSupported: boolean;
   isCarConfigSupported: boolean;
+  isEventsSupported: boolean;
   isLoading: boolean;
   hasError: boolean;
 }
@@ -86,6 +87,7 @@ describe("useSupportedApis", () => {
       isDeviceStatusSupported: true,
       isTimeApiSupported: false,
       isCarConfigSupported: false,
+      isEventsSupported: false,
       isLoading: false,
       hasError: false,
     };

--- a/website/src/test/utils.tsx
+++ b/website/src/test/utils.tsx
@@ -53,6 +53,7 @@ const mockSupportedApisProvider = {
   isDeviceStatusSupported: true,
   isTimeApiSupported: true,
   isCarConfigSupported: false,
+  isEventsSupported: false,
   isLoading: false,
   hasError: false,
 };


### PR DESCRIPTION
## Summary

Console-side changes to support the BMI160 IMU package (`imu_pkg`) introduced in [deepracer-custom-car#72](https://github.com/aws-deepracer-community/deepracer-custom-car/pull/72).

## Features

### IMU Settings (Car Config)

- New IMU section in the Settings page, rendered only when the `imu` capability is reported by the backend (x86 / original DeepRacer hardware only).
- **Enable IMU** toggle — enables/disables the IMU node at next restart.
- **Crash Detection** slider — index-based Cloudscape `Slider` snapping to `[Disabled, 1.5 G, 2.0 G, 2.5 G, 3.0 G]`. Displays "Disabled" at index 0, otherwise `N G`.
- **Pickup Detection** slider — index-based Cloudscape `Slider` snapping to `[Disabled, 0.5 G, 0.75 G, 0.95 G]`. Only shown when IMU is enabled.
- Both sliders include reference tick marks at every step.
- Config persisted via `POST /api/car_config`; `crash_enabled` / `pickup_enabled` booleans derived server-side.

### Real-Time Safety Stop Notification (SSE)

- `EventSource` connection to `GET /api/events` (Server-Sent Events), opened on the **Control Vehicle (home) page**.
- Active only when **all three** conditions hold:
  1. `isEventsSupported` — `/api/events` is listed in `supported_apis`
  2. `config.imu.enabled` — IMU is enabled in the car config
  3. `isInferenceRunning` — the vehicle is currently active (started)
- When any condition becomes false (vehicle stopped, IMU disabled, page unmount) the `EventSource` is closed automatically.
- Listens for `imu_stop` events emitted when the IMU node triggers a safety stop (`"crash"` or `"pickup"` reason).
- Injects a dismissible Cloudscape `Flashbar` warning into the home page notification bar: **"IMU safety stop — Crash detected"** or **"IMU safety stop — Vehicle lifted"**.
- **Auto-dismisses after 5 seconds** of no new events; timer resets if a repeat event arrives while the notification is already visible.
- User can also dismiss manually; timer is cleared on dismissal.

### Supported APIs

- Added `isEventsSupported` to `SupportedApisState` — checks for `"/api/events"` in the `supported_apis` response.

## Files changed

| File | Change |
|---|---|
| `src/common/hooks/use-supported-apis.ts` | Added `isEventsSupported` state + capability check |
| `src/common/hooks/use-car-config.ts` | Added `imu` section to `CarConfig` and `Capabilities` interfaces |
| `src/components/settings/car-config-container.tsx` | IMU settings UI (toggle + two index-based sliders) |
| `src/pages/home.tsx` | SSE `EventSource` hook for IMU stop notifications (vehicle-active guard) |
| `src/test/utils.tsx`, `src/test/unit/*.test.tsx` | Updated mocks with `isEventsSupported: false` |